### PR TITLE
ci: add PR-build workflow (fmt, clippy -D warnings, build, test, shell)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+# Cancel previous runs of this workflow on the same ref when a new commit comes in.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  rust:
+    name: Rust (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable, with rustfmt + clippy)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt --check
+        run: cargo fmt --all --check
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: cargo build
+        run: cargo build --release
+
+      - name: cargo test
+        run: cargo test --release
+
+  shell:
+    name: Shell (zsh -n)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install zsh
+        run: sudo apt-get update && sudo apt-get install -y zsh
+
+      - name: Syntax-check claude-switch.sh
+        run: zsh -n claude-switch.sh
+
+      - name: Syntax-check generated shell templates
+        run: |
+          zsh -n shell/init.zsh
+          bash -n shell/init.bash
+          bash -n shell/claude-wrapper.sh

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -20,7 +20,9 @@ use std::path::Path;
 
 use crate::config::AppConfig;
 
+#[cfg(not(windows))]
 const WRAPPER_TEMPLATE: &str = include_str!("../shell/claude-wrapper.sh");
+#[cfg(not(windows))]
 const WRAPPER_PLACEHOLDER: &str = "__CLAUDE_ACC_BIN__";
 
 /// `~/.claude/ide` — the canonical IDE lock-file directory.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` that runs on every PR and on push to `master`, so regressions are caught before merge instead of waiting for the next release-please run.

This is the follow-up to #8 — that PR cleaned the tree of clippy warnings, this PR enforces it.

## What runs

**`rust` matrix** (ubuntu-latest, macos-latest, windows-latest):
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings` (also `RUSTFLAGS: -D warnings`)
- `cargo build --release`
- `cargo test --release`

**`shell` (ubuntu-latest):**
- `zsh -n claude-switch.sh`
- `zsh -n shell/init.zsh`
- `bash -n shell/init.bash`
- `bash -n shell/claude-wrapper.sh`

## Implementation notes

- `concurrency` group cancels in-progress runs on the same PR ref when a new commit comes in, but lets master pushes finish to completion (so we don't race release-please).
- `Swatinem/rust-cache@v2` caches deps to keep wall time reasonable across 3-platform matrix.
- `permissions: contents: read` — minimum needed; no PR-write or release-write here.
- `RUSTFLAGS: -D warnings` belt-and-suspenders alongside the explicit clippy flag, so plain `cargo build` would also catch warnings.

## Test plan

Verified locally on macOS:
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo build --release` — clean
- [x] `cargo test --release` — passes (0 tests defined)
- [x] All 4 shell files parse with `zsh -n` / `bash -n`

CI itself will run on this PR — that's the real verification.

`ci:` prefix is hidden in the release-please changelog config, no release impact.