### PR TITLE
chore: don't ignore /.claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-/.claude/


### PR DESCRIPTION
Reverts the `/.claude/` ignore added in #8.

That line was added to keep my session's `scheduled_tasks.lock` out of commits, but it also blanket-ignores `.claude/settings.local.json` and any other files a maintainer might want to track per-project. The lockfile was a one-off accident — not a recurring problem.

`chore:` prefix → hidden in changelog, no release impact.