### PR TITLE
docs: migration guide between Rust and shell distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,31 @@ $ claude-acc status
 Active account: ~/.claude/ (standard)
 ```
 
+## Switching between Rust and shell
+
+Both versions read and write the same files under `~/.claude-switch/`:
+
+```
+~/.claude-switch/
+├── accounts/        ← per-account CLAUDE_CONFIG_DIR
+├── config           ← default account
+└── links            ← directory ↔ account bindings
+```
+
+So you can move from one to the other without re-creating accounts or relinking directories. Steps:
+
+**Shell → Rust:**
+1. Install the Rust binary: download from [Releases](https://github.com/Nemo-Illusionist/claude-code-account-switcher/releases) and run `claude-acc install`. The Rust install command writes its own shell-init line.
+2. Remove the `source ~/.claude-switch.sh` line from your `~/.zshrc` (the Rust init handles activation now).
+3. Optionally `rm ~/.claude-switch.sh`.
+
+**Rust → shell:**
+1. `cp claude-switch.sh ~/.claude-switch.sh` and add `source ~/.claude-switch.sh` to `~/.zshrc`.
+2. Remove the `eval "$(... claude-acc init zsh)"` line from `~/.zshrc`.
+3. Optionally `rm ~/.claude-switch/bin/claude-acc ~/.claude-switch/bin/claude` (the wrapper). The shell version regenerates its own wrapper on `source`.
+
+Account credentials, links, and the `default` setting carry over without any changes.
+
 ## Releases
 
 Releases are managed automatically by [release-please](https://github.com/googleapis/release-please). On every push to `master`, an action reads the [conventional-commit](https://www.conventionalcommits.org/) messages and keeps a rolling "Release PR" open with a version bump and changelog. Merging that PR creates a tag and triggers cross-platform binary builds (macOS x64/arm64, Linux x64/arm64, Windows x64) that are attached to the release.

--- a/README.ru.md
+++ b/README.ru.md
@@ -208,6 +208,31 @@ $ claude-acc status
 Активный аккаунт: ~/.claude/ (стандартный)
 ```
 
+## Переключение между Rust и shell
+
+Оба варианта читают и пишут одни и те же файлы в `~/.claude-switch/`:
+
+```
+~/.claude-switch/
+├── accounts/        ← CLAUDE_CONFIG_DIR для каждого аккаунта
+├── config           ← дефолтный аккаунт
+└── links            ← привязки директория ↔ аккаунт
+```
+
+Поэтому переключаться можно без пересоздания аккаунтов и перепривязок. Шаги:
+
+**Shell → Rust:**
+1. Установить Rust-бинарник: скачать из [Releases](https://github.com/Nemo-Illusionist/claude-code-account-switcher/releases) и запустить `claude-acc install`. Эта команда сама добавит свою shell-init строку.
+2. Удалить строку `source ~/.claude-switch.sh` из `~/.zshrc` (за активацию теперь отвечает Rust-init).
+3. По желанию — `rm ~/.claude-switch.sh`.
+
+**Rust → shell:**
+1. `cp claude-switch.sh ~/.claude-switch.sh`, добавить `source ~/.claude-switch.sh` в `~/.zshrc`.
+2. Удалить строку `eval "$(... claude-acc init zsh)"` из `~/.zshrc`.
+3. По желанию — `rm ~/.claude-switch/bin/claude-acc ~/.claude-switch/bin/claude` (wrapper). Shell-версия пересоздаст свой wrapper при `source`.
+
+Учётные данные аккаунтов, привязки и дефолт сохраняются как есть.
+
 ## Релизы
 
 Релизы автоматизированы через [release-please](https://github.com/googleapis/release-please). На каждый push в `master` action читает [conventional commits](https://www.conventionalcommits.org/ru/v1.0.0/) и держит открытой одну "Release PR" с бампом версии и changelog. Мерж этой PR создаёт тег и собирает кроссплатформенные бинарники (macOS x64/arm64, Linux x64/arm64, Windows x64), приклеивая их к релизу.


### PR DESCRIPTION
## Summary

The README intro mentions "both share the same on-disk format so you can switch between them freely" but doesn't actually walk through *how*. Adds a "Switching between Rust and shell" section (en + ru) with concrete steps for each direction, plus a reminder that accounts/links/default carry over untouched.

## Changes

- New section in `README.md` and `README.ru.md` immediately before "Releases".
- Two-direction migration:
  - **Shell → Rust**: `claude-acc install` (handles its own .zshrc), then remove the `source ~/.claude-switch.sh` line.
  - **Rust → shell**: `cp claude-switch.sh ~/.claude-switch.sh` + source line, remove the Rust eval-init line, optionally remove the binaries (the shell version regenerates its own wrapper).

## Test plan

- [x] No code changes — README only
- [x] Steps verified mentally against the actual install logic in `src/commands/install.rs` and `claude-switch.sh`'s init block

`docs:` prefix → visible in changelog under "Documentation". Will trigger a patch bump on next release-please run.