### PR TITLE
ci: split CI into path-filtered Rust and Shell workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,14 +1,24 @@
-name: CI
+name: Rust
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'shell/**'
+      - '.github/workflows/rust.yml'
   push:
-    branches:
-      - master
+    branches: [master]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'shell/**'
+      - '.github/workflows/rust.yml'
 
-# Cancel previous runs of this workflow on the same ref when a new commit comes in.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: rust-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -20,7 +30,7 @@ env:
 
 jobs:
   rust:
-    name: Rust (${{ matrix.os }})
+    name: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -47,21 +57,3 @@ jobs:
 
       - name: cargo test
         run: cargo test --release
-
-  shell:
-    name: Shell (zsh -n)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install zsh
-        run: sudo apt-get update && sudo apt-get install -y zsh
-
-      - name: Syntax-check claude-switch.sh
-        run: zsh -n claude-switch.sh
-
-      - name: Syntax-check generated shell templates
-        run: |
-          zsh -n shell/init.zsh
-          bash -n shell/init.bash
-          bash -n shell/claude-wrapper.sh

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,0 +1,40 @@
+name: Shell
+
+on:
+  pull_request:
+    paths:
+      - 'claude-switch.sh'
+      - 'shell/**'
+      - '.github/workflows/shell.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'claude-switch.sh'
+      - 'shell/**'
+      - '.github/workflows/shell.yml'
+
+concurrency:
+  group: shell-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  shell:
+    name: zsh -n / bash -n
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install zsh
+        run: sudo apt-get update && sudo apt-get install -y zsh
+
+      - name: Syntax-check claude-switch.sh
+        run: zsh -n claude-switch.sh
+
+      - name: Syntax-check generated shell templates
+        run: |
+          zsh -n shell/init.zsh
+          bash -n shell/init.bash
+          bash -n shell/claude-wrapper.sh


### PR DESCRIPTION
## Summary

The combined \`ci.yml\` (#9) fired the full Rust matrix (3 platforms × fmt + clippy + build + test, ~5 min wall) plus the shell \`zsh -n\` job on every PR — even README-only / docs-only changes. Splitting into two workflows with \`paths\` filters so each runs only when its inputs change.

## Trigger matrix

| Path changed | rust.yml | shell.yml |
|---|---|---|
| \`src/**\` | ✓ | — |
| \`Cargo.toml\` / \`Cargo.lock\` | ✓ | — |
| \`shell/**\` (init.zsh/bash, claude-wrapper.sh, etc.) | ✓ | ✓ |
| \`claude-switch.sh\` | — | ✓ |
| \`README*.md\`, \`LICENSE\`, \`.gitignore\`, release-please configs | — | — |

Why \`shell/**\` triggers Rust too: \`src/commands/init.rs\` and \`src/ide.rs\` use \`include_str!\` on \`shell/init.{zsh,bash,ps1}\` and \`shell/claude-wrapper.sh\`. Changing those changes the compiled binary's behaviour, so the matrix should re-run.

## Notes

- Both workflows keep the same checks they had in \`ci.yml\` — only the trigger filter changed.
- If either workflow becomes a required check on \`master\` later, GitHub will block PRs that don't trigger it (because the status never reports). At that point we'd switch to \`dorny/paths-filter\` running always and skipping jobs internally. Not needed yet.
- Self-edit triggering: each workflow lists itself in its \`paths:\`, so editing the file re-triggers the workflow. This PR's diff doesn't touch \`shell/**\` or \`claude-switch.sh\`, so only \`rust.yml\` should fire (because the rust.yml file itself changed). \`shell.yml\` is a brand-new file, so its first run will be the next PR that touches a shell-relevant path.

## Test plan

The PR itself is the test:
- [ ] \`Rust\` workflow fires (triggered by \`.github/workflows/rust.yml\` change), passes
- [ ] \`Shell\` workflow does NOT fire on this PR (no shell-relevant paths changed)

\`ci:\` prefix → hidden in changelog.