### PR TITLE
feat: `claude-acc doctor` for OAuth identity audit (Phase 1 of identity-lock)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +113,8 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "dirs",
+ "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -111,6 +122,35 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -131,6 +171,16 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -157,6 +207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +226,12 @@ checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -213,6 +275,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +365,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +381,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -281,3 +408,9 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ repository = "https://github.com/Nemo-Illusionist/claude-code-account-switcher"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
+serde_json = "1"
+sha2 = "0.10"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ claude-acc link work
 | `claude-acc links` | Show all directory links |
 | `claude-acc status` | Show active account |
 | `claude-acc run <name>` | Run claude under a specific account |
+| `claude-acc doctor` | Audit each account's actual OAuth identity |
 | `claude-acc install` | Install binary and shell integration |
 
 ## How it works
@@ -178,6 +179,25 @@ claude-acc link work-ml
 ```
 
 > Note: `claude-acc add` runs `claude login`, so you'll need to log in again (same account, just a new config directory).
+
+## Auditing identities (`doctor`)
+
+`claude-acc add` and `claude-acc login` both run `claude auth login` under a per-account `CLAUDE_CONFIG_DIR`. Whatever Anthropic account you sign in with becomes the identity for that directory — and there's no built-in surface to see which account is actually behind a given config dir. If you accidentally log in with the wrong identity (browser auto-fill, a stale tab), the switch is silent: rate limits, conversation history, and billing leak across what you thought were isolated accounts.
+
+`claude-acc doctor` reads each account's OAuth token from the macOS Keychain (with a `.credentials.json` fallback for non-Keychain installs), calls `https://api.anthropic.com/api/oauth/profile`, and prints the live email + UUID:
+
+```
+$ claude-acc doctor
+Auditing 2 account(s):
+  ✓ work      alice@anthropic.com  uuid=aa6c22d5-…
+  ? personal  no token (run: claude-acc login personal)
+
+1 of 2 accounts healthy.
+```
+
+It's purely a read-only audit — nothing is intercepted, no `claude` invocation is gated. Run it whenever you want to confirm a config dir is bound to the identity you expect. Requires `security`, `curl`, `jq`, and `shasum` (all preinstalled on macOS); the Rust binary uses native `serde_json` and `sha2` instead and only shells out to `security` and `curl`.
+
+> **macOS only for now.** The Keychain hashing scheme is reverse-engineered from Claude Code's internals, so non-macOS platforms (where Claude Code uses libsecret / Credential Manager) aren't covered yet.
 
 ## Language
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -74,6 +74,7 @@ claude-acc link work
 | `claude-acc links` | Показать все привязки директорий |
 | `claude-acc status` | Показать активный аккаунт |
 | `claude-acc run <имя>` | Запустить claude под конкретным аккаунтом |
+| `claude-acc doctor` | Аудит реальной OAuth-личности каждого аккаунта |
 | `claude-acc install` | Установить бинарник и shell-интеграцию |
 
 ## Как это работает
@@ -177,6 +178,25 @@ claude-acc link work-ml
 ```
 
 > Примечание: `claude-acc add` запускает `claude login`, поэтому нужно будет залогиниться повторно (тот же аккаунт, просто новая папка конфига).
+
+## Аудит личностей (`doctor`)
+
+`claude-acc add` и `claude-acc login` оба запускают `claude auth login` под персональным `CLAUDE_CONFIG_DIR`. С каким Anthropic-аккаунтом вы залогинились — тот и привязан к этой директории. Встроенного способа увидеть, *какой именно* аккаунт реально стоит за config dir, нет. Если случайно залогинились не той учёткой (browser auto-fill, забытая вкладка), переключение происходит молча: лимиты, история диалогов и биллинг перепутаются между «изолированными» аккаунтами без всяких признаков.
+
+`claude-acc doctor` читает OAuth-токен каждого аккаунта из macOS Keychain (с fallback на `.credentials.json` для установок без Keychain), дёргает `https://api.anthropic.com/api/oauth/profile` и печатает реальный email + UUID:
+
+```
+$ claude-acc doctor
+Проверка 2 аккаунт(ов):
+  ✓ work      alice@anthropic.com  uuid=aa6c22d5-…
+  ? personal  нет токена (запустите: claude-acc login personal)
+
+1 из 2 аккаунтов в порядке.
+```
+
+Это исключительно read-only аудит — ничего не перехватывается, запуск `claude` не блокируется. Запускайте когда хочется убедиться, что за config dir стоит ожидаемая личность. Требует `security`, `curl`, `jq`, `shasum` (всё предустановлено на macOS); Rust-бинарник использует нативные `serde_json` и `sha2`, шеллаутит только `security` и `curl`.
+
+> **Пока только macOS.** Схема хеширования Keychain reverse-engineered из внутренностей Claude Code; на других платформах (где используется libsecret / Credential Manager) пока не работает.
 
 ## Язык
 

--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -58,6 +58,7 @@ _claude_msg_en=(
     help_links          "Show all directory links"
     help_status         "Current account and context"
     help_run            "Run claude under a specific account"
+    help_doctor         "Audit each account OAuth identity (email, UUID)"
     help_help           "Help"
     list_empty          "No accounts. Add one: claude-acc add <name>"
     list_header         "Claude Code accounts:"
@@ -92,6 +93,12 @@ _claude_msg_en=(
     name_invalid        "Account name must contain only letters, digits, hyphens, and underscores."
     run_usage           "Usage: claude-acc run <name> [args...]"
     run_not_found       "Account '%s' not found."
+    doctor_header       "Auditing %d account(s):"
+    doctor_no_token     "no token (run: claude-acc login %s)"
+    doctor_offline      "token present, but API unreachable"
+    doctor_all_ok       "All accounts healthy."
+    doctor_partial      "%d of %d accounts healthy."
+    doctor_missing_dep  "claude-acc doctor needs '%s' on PATH."
     unlink_none         "No link for the current directory."
     unlink_done         "Unlinked %s. Default account will be used."
     status_active       "Active account: %s %s"
@@ -117,6 +124,7 @@ _claude_msg_ru=(
     help_links          "Показать все привязки директорий"
     help_status         "Текущий аккаунт и контекст"
     help_run            "Запустить claude под конкретным аккаунтом"
+    help_doctor         "Аудит OAuth-личности каждого аккаунта (email, UUID)"
     help_help           "Справка"
     list_empty          "Нет аккаунтов. Добавьте: claude-acc add <name>"
     list_header         "Аккаунты Claude Code:"
@@ -151,6 +159,12 @@ _claude_msg_ru=(
     name_invalid        "Имя аккаунта может содержать только буквы, цифры, дефисы и подчёркивания."
     run_usage           "Использование: claude-acc run <name> [args...]"
     run_not_found       "Аккаунт '%s' не найден."
+    doctor_header       "Проверка %d аккаунт(ов):"
+    doctor_no_token     "нет токена (запустите: claude-acc login %s)"
+    doctor_offline      "токен есть, API недоступен"
+    doctor_all_ok       "Все аккаунты в порядке."
+    doctor_partial      "%d из %d аккаунтов в порядке."
+    doctor_missing_dep  "claude-acc doctor требует '%s' в PATH."
     unlink_none         "Нет привязки для текущей директории."
     unlink_done         "Привязка убрана для %s. Будет использован дефолтный аккаунт."
     status_active       "Активный аккаунт: %s %s"
@@ -392,6 +406,7 @@ _claude_acc_help() {
     echo "  claude-acc links             $(_msg help_links)"
     echo "  claude-acc status            $(_msg help_status)"
     echo "  claude-acc run <name> [...]  $(_msg help_run)"
+    echo "  claude-acc doctor            $(_msg help_doctor)"
 }
 
 _claude_acc_list() {
@@ -673,6 +688,87 @@ _claude_acc_run() {
     CLAUDE_CONFIG_DIR="$acc_dir" command claude "$@"
 }
 
+# --- Identity audit (Phase 1: passive, read-only) ---
+# Reads each account's OAuth token from macOS Keychain (with .credentials.json
+# fallback), calls /api/oauth/profile, prints email + UUID. Doesn't change
+# anything. Requires: security, curl, jq, shasum.
+
+_claude_acc_token() {
+    local acc_dir="$1" hash service token
+    hash=$(printf '%s' "$acc_dir" | shasum -a 256 2>/dev/null | cut -c1-8)
+    [[ -z "$hash" ]] && return 1
+    service="Claude Code-credentials-${hash}"
+    token=$(security find-generic-password -s "$service" -a "$(id -un)" -w 2>/dev/null)
+    if [[ -n "$token" ]]; then
+        printf '%s' "$token" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null
+        return 0
+    fi
+    jq -r '.claudeAiOauth.accessToken // empty' "$acc_dir/.credentials.json" 2>/dev/null
+}
+
+# Echoes "<email>\t<uuid>" or empty on failure.
+_claude_acc_identity() {
+    local token="$1"
+    [[ -z "$token" ]] && return 1
+    curl -sf --max-time 5 \
+        -H "Authorization: Bearer $token" \
+        -H "anthropic-beta: oauth-2025-04-20" \
+        https://api.anthropic.com/api/oauth/profile 2>/dev/null \
+        | jq -r '"\(.account.email // "<unknown>")\t\(.account.uuid // "<unknown>")"' 2>/dev/null
+}
+
+_claude_acc_doctor() {
+    local dep
+    for dep in security curl jq shasum; do
+        if ! command -v "$dep" >/dev/null 2>&1; then
+            _msg doctor_missing_dep "$dep"
+            return 1
+        fi
+    done
+
+    local accounts=("$CLAUDE_SWITCH_ACCOUNTS_DIR"/*(N:t))
+    if [[ ${#accounts} -eq 0 ]]; then
+        _msg list_empty
+        return 0
+    fi
+
+    _msg doctor_header "${#accounts}"
+
+    # Compute label width for aligned output.
+    local width=0 acc
+    for acc in "${accounts[@]}"; do
+        (( ${#acc} > width )) && width=${#acc}
+    done
+
+    local healthy=0 token identity email uuid
+    for acc in "${accounts[@]}"; do
+        local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$acc"
+        token=$(_claude_acc_token "$acc_dir")
+        if [[ -z "$token" ]]; then
+            printf "  ? %-${width}s  %s\n" "$acc" "$(_msg doctor_no_token "$acc")"
+            continue
+        fi
+        identity=$(_claude_acc_identity "$token")
+        if [[ -z "$identity" ]]; then
+            printf "  ? %-${width}s  %s\n" "$acc" "$(_msg doctor_offline)"
+            continue
+        fi
+        email="${identity%%	*}"
+        uuid="${identity#*	}"
+        printf "  ✓ %-${width}s  %s  uuid=%s\n" "$acc" "$email" "$uuid"
+        (( healthy++ ))
+    done
+
+    echo ""
+    if (( healthy == ${#accounts} )); then
+        _msg doctor_all_ok
+        return 0
+    else
+        _msg doctor_partial "$healthy" "${#accounts}"
+        return 1
+    fi
+}
+
 # =============================================================
 # Единая точка входа
 # =============================================================
@@ -693,6 +789,7 @@ claude-acc() {
         links)   _claude_acc_links ;;
         status)  _claude_acc_status "$@" ;;
         run)     _claude_acc_run "$@" ;;
+        doctor)  _claude_acc_doctor ;;
         help)    _claude_acc_help ;;
         *)       _claude_acc_help ;;
     esac
@@ -716,6 +813,7 @@ _claude_acc_completion() {
         "links:$(_msg help_links)"
         "status:$(_msg help_status)"
         "run:$(_msg help_run)"
+        "doctor:$(_msg help_doctor)"
         "help:$(_msg help_help)"
     )
 

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -29,7 +29,7 @@ _claude_acc_complete() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     if [[ $COMP_CWORD -eq 1 ]]; then
-        COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status run help" -- "$cur"))
+        COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status run doctor help" -- "$cur"))
     elif [[ $COMP_CWORD -eq 2 ]]; then
         case "$prev" in
             login|remove|run)

--- a/shell/init.ps1
+++ b/shell/init.ps1
@@ -27,7 +27,7 @@ Register-ArgumentCompleter -CommandName claude-acc -ScriptBlock {
     $count = $words.Count
 
     if ($count -le 2) {
-        $cmds = @('list','add','login','remove','default','reset','link','unlink','links','status','run','help')
+        $cmds = @('list','add','login','remove','default','reset','link','unlink','links','status','run','doctor','help')
         $cmds | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -37,6 +37,7 @@ _claude_acc_completion() {
         'links:Show all links'
         'status:Current account info'
         'run:Run claude under a specific account'
+        'doctor:Audit each account OAuth identity'
     )
     if (( CURRENT == 2 )); then
         _describe 'command' subcmds

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,0 +1,52 @@
+use crate::config::AppConfig;
+use crate::i18n::{I18n, Msg};
+use crate::identity::{self, AuditResult};
+
+pub fn run(config: &AppConfig, i18n: &I18n) -> i32 {
+    let accounts = match config.list_accounts() {
+        Ok(v) => v,
+        Err(_) => return 1,
+    };
+    if accounts.is_empty() {
+        i18n.print(Msg::ListEmpty);
+        return 0;
+    }
+
+    i18n.print(Msg::DoctorHeader(accounts.len()));
+
+    let label_w = accounts.iter().map(|a| a.len()).max().unwrap_or(0);
+    let mut healthy = 0usize;
+
+    for acc in &accounts {
+        let acc_dir = config.account_path(acc);
+        let pad = " ".repeat(label_w.saturating_sub(acc.len()));
+        match identity::audit_account(&acc_dir) {
+            AuditResult::Ok(p) => {
+                healthy += 1;
+                let email = p.email.as_deref().unwrap_or("<unknown>");
+                let uuid = p.uuid.as_deref().unwrap_or("<unknown>");
+                println!("  ✓ {}{}  {}  uuid={}", acc, pad, email, uuid);
+            }
+            AuditResult::NoToken => {
+                println!(
+                    "  ? {}{}  {}",
+                    acc,
+                    pad,
+                    i18n.msg(Msg::DoctorNoToken(acc.clone()))
+                );
+            }
+            AuditResult::Offline => {
+                println!("  ? {}{}  {}", acc, pad, i18n.msg(Msg::DoctorOffline));
+            }
+        }
+    }
+
+    println!();
+    if healthy == accounts.len() {
+        i18n.print(Msg::DoctorAllOk);
+        0
+    } else {
+        i18n.print(Msg::DoctorPartial(healthy, accounts.len()));
+        1
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod activate;
 pub mod add;
 pub mod completions;
 pub mod default;
+pub mod doctor;
 pub mod init;
 pub mod install;
 pub mod link;

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -198,6 +198,26 @@ impl I18n {
             (Msg::InstallShellManual(ref line), Lang::Ru) => {
                 format!("Добавьте в конфиг шелла:\n  {}", line)
             }
+
+            // doctor
+            (Msg::DoctorHeader(n), Lang::En) => format!("Auditing {} account(s):", n),
+            (Msg::DoctorHeader(n), Lang::Ru) => format!("Проверка {} аккаунт(ов):", n),
+            (Msg::DoctorNoToken(ref name), Lang::En) => {
+                format!("no token (run: claude-acc login {})", name)
+            }
+            (Msg::DoctorNoToken(ref name), Lang::Ru) => {
+                format!("нет токена (запустите: claude-acc login {})", name)
+            }
+            (Msg::DoctorOffline, Lang::En) => s("token present, but API unreachable"),
+            (Msg::DoctorOffline, Lang::Ru) => s("токен есть, API недоступен"),
+            (Msg::DoctorAllOk, Lang::En) => s("All accounts healthy."),
+            (Msg::DoctorAllOk, Lang::Ru) => s("Все аккаунты в порядке."),
+            (Msg::DoctorPartial(ok, total), Lang::En) => {
+                format!("{} of {} accounts healthy.", ok, total)
+            }
+            (Msg::DoctorPartial(ok, total), Lang::Ru) => {
+                format!("{} из {} аккаунтов в порядке.", ok, total)
+            }
         }
     }
 
@@ -257,4 +277,9 @@ pub enum Msg {
     InstallShellUpdated(String),
     InstallShellAdded(String),
     InstallShellManual(String),
+    DoctorHeader(usize),
+    DoctorNoToken(String),
+    DoctorOffline,
+    DoctorAllOk,
+    DoctorPartial(usize, usize),
 }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,0 +1,132 @@
+// Read OAuth identity for a given account dir.
+//
+// Claude Code stores the OAuth token in macOS Keychain under service
+// "Claude Code-credentials-<hash>" where hash = sha256(CLAUDE_CONFIG_DIR)
+// truncated to 8 hex chars. This is reverse-engineered from Claude Code's
+// internal `dV()` function and could change in future versions — if it does,
+// keychain reads will silently miss and we'll fall back to .credentials.json.
+//
+// The plaintext .credentials.json fallback is what older Claude Code versions
+// (and current Linux/Windows builds) use when no keychain backend is available.
+//
+// HTTP and shell-out (security, curl) instead of native deps to keep the
+// binary small. The Anthropic OAuth profile endpoint is undocumented and
+// might change.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use sha2::{Digest, Sha256};
+
+pub struct Profile {
+    pub email: Option<String>,
+    pub uuid: Option<String>,
+    #[allow(dead_code)]
+    pub organization: Option<String>,
+}
+
+pub enum AuditResult {
+    Ok(Profile),
+    NoToken,
+    Offline,
+}
+
+pub fn audit_account(acc_dir: &Path) -> AuditResult {
+    let Some(token) = read_token(acc_dir) else {
+        return AuditResult::NoToken;
+    };
+    match fetch_profile(&token) {
+        Some(p) => AuditResult::Ok(p),
+        None => AuditResult::Offline,
+    }
+}
+
+fn read_token(acc_dir: &Path) -> Option<String> {
+    if let Some(t) = keychain_token(acc_dir) {
+        return Some(t);
+    }
+    plaintext_token(acc_dir)
+}
+
+fn keychain_token(acc_dir: &Path) -> Option<String> {
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+    let acc_str = acc_dir.to_str()?;
+    let mut hasher = Sha256::new();
+    hasher.update(acc_str.as_bytes());
+    let digest = hasher.finalize();
+    let hash: String = digest
+        .iter()
+        .take(4)
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    let service = format!("Claude Code-credentials-{}", hash);
+
+    let user = whoami_short()?;
+    let out = Command::new("security")
+        .args(["find-generic-password", "-s", &service, "-a", &user, "-w"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    extract_access_token(&raw)
+}
+
+fn plaintext_token(acc_dir: &Path) -> Option<String> {
+    let path = acc_dir.join(".credentials.json");
+    let content = fs::read_to_string(&path).ok()?;
+    extract_access_token(&content)
+}
+
+fn extract_access_token(raw: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(raw).ok()?;
+    v.get("claudeAiOauth")?
+        .get("accessToken")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+fn whoami_short() -> Option<String> {
+    let out = Command::new("id").arg("-un").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn fetch_profile(token: &str) -> Option<Profile> {
+    // Shell out to curl to avoid pulling in HTTP+TLS deps. macOS ships curl;
+    // Linux distros that have Claude Code installed also have curl.
+    let out = Command::new("curl")
+        .args(["-sf", "--max-time", "5"])
+        .args(["-H", &format!("Authorization: Bearer {}", token)])
+        .args(["-H", "anthropic-beta: oauth-2025-04-20"])
+        .arg("https://api.anthropic.com/api/oauth/profile")
+        .output()
+        .ok()?;
+    if !out.status.success() || out.stdout.is_empty() {
+        return None;
+    }
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    Some(Profile {
+        email: v
+            .get("account")
+            .and_then(|a| a.get("email"))
+            .and_then(|e| e.as_str())
+            .map(|s| s.to_string()),
+        uuid: v
+            .get("account")
+            .and_then(|a| a.get("uuid"))
+            .and_then(|u| u.as_str())
+            .map(|s| s.to_string()),
+        organization: v
+            .get("organization")
+            .and_then(|o| o.get("name"))
+            .and_then(|n| n.as_str())
+            .map(|s| s.to_string()),
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod commands;
 mod config;
 mod i18n;
 mod ide;
+mod identity;
 mod resolve;
 
 use clap::{Parser, Subcommand};
@@ -50,6 +51,8 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Audit each account's actual OAuth identity (email, UUID)
+    Doctor,
     /// Install binary and shell integration
     Install,
     /// Output shell activation code (used by shell hook)
@@ -91,6 +94,7 @@ fn main() {
         Some(Commands::Links) => commands::links::run(&config, &i18n),
         Some(Commands::Status) => commands::status::run(&config, &i18n),
         Some(Commands::Run { name, args }) => commands::run::run(&config, &i18n, &name, &args),
+        Some(Commands::Doctor) => std::process::exit(commands::doctor::run(&config, &i18n)),
         Some(Commands::Install) => commands::install::run(&config, &i18n),
         Some(Commands::Activate { shell }) => {
             let syntax = match shell.as_str() {


### PR DESCRIPTION
## Summary

Adds `claude-acc doctor` — a passive, read-only audit that surfaces the actual Anthropic identity behind each managed account dir. Solves the "did my OAuth get swapped without me noticing?" question raised by [@lis186](https://github.com/lis186)'s fork, but as opt-in inspection rather than a hot-path gate.

For each account:
1. Reads the OAuth token from macOS Keychain (service `Claude Code-credentials-<sha256(CCD)[0:8]>`, reverse-engineered from Claude Code's internal `dV()`). Falls back to `<acc>/.credentials.json` if no Keychain entry.
2. Calls `https://api.anthropic.com/api/oauth/profile` with the `oauth-2025-04-20` beta header.
3. Prints account label, email, UUID, with `✓` / `?` symbol marking ok / no-token / offline.

Exits 0 when every account audited cleanly, 1 otherwise. Doesn't intercept or gate any `claude` invocation.

## Why phased

We discussed the full identity-lock proposal (lis186 fork) and concluded it's overkill until drift is observed in practice — see plan in chat. Phases 2 (`.identity-lock.json` + `claude-acc lock`) and 3 (wrapper-gate) deferred pending evidence. Issues will be opened to track them with a "is this needed?" prompt.

## Sample output

```
$ claude-acc doctor
Auditing 2 account(s):
  ✓ work      alice@anthropic.com  uuid=aa6c22d5-…
  ? personal  no token (run: claude-acc login personal)

1 of 2 accounts healthy.
```

## Implementation

- **Rust** — new `src/identity.rs` and `src/commands/doctor.rs`. Two new deps:
  - `serde_json` (parse keychain JSON + API response)
  - `sha2` (compute the keychain hash)
  HTTP and Keychain access shell out to `curl` and `security` to keep the binary lean (~250KB added) and avoid pulling in a TLS stack for a feature that's macOS-only anyway.
- **Shell** — mirrors the same logic in `_claude_acc_doctor` using `security` / `curl` / `jq` / `shasum`. Friendly i18n error if any of those are missing on PATH.
- New i18n keys for both en + ru.
- Help text, completions (zsh / bash / pwsh), and dispatcher all updated.
- README sections (en + ru) documenting what the command does, why, and the macOS-only caveat with the reverse-engineering risk.

## Risks acknowledged in the README

- Keychain hash scheme `sha256(CCD)[0:8]` is reverse-engineered from Claude Code's private internals. If they change `dV()`, our keychain read will silently miss and we'll fall back to `.credentials.json` — degrades cleanly, but doctor will start saying "no token" for everyone.
- `/api/oauth/profile` is undocumented Anthropic OAuth endpoint. Could change.
- macOS only at this iteration (Linux/Windows would need libsecret / Credential Manager backends).

These are why the feature is opt-in (you only run it when you want to check), not on the hot path.

## Test plan

Verified locally on macOS against a real account:
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --release` clean (no tests defined)
- [x] `./target/release/claude-acc doctor` against logged-in `work` account: prints email + UUID
- [x] Doctor with an account dir that has no keychain entry: `?` line + "run claude-acc login" hint, exit 1
- [x] Shell version: same output for the same account, syntax-clean (`zsh -n`)
- [x] All four shell template files (`init.zsh`, `init.bash`, `init.ps1`, `claude-wrapper.sh`) parse

`feat:` prefix → release-please will bump the next release as a minor (0.2.0 → 0.3.0).