### PR TITLE
feat: cache doctor result and show email in `list` / `status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,20 @@ Auditing 2 account(s):
 
 It's purely a read-only audit — nothing is intercepted, no `claude` invocation is gated. Run it whenever you want to confirm a config dir is bound to the identity you expect. Requires `security`, `curl`, `jq`, and `shasum` (all preinstalled on macOS); the Rust binary uses native `serde_json` and `sha2` instead and only shells out to `security` and `curl`.
 
+`doctor` also caches the result to `~/.claude-switch/accounts/<name>/.account-info.json` so `list` and `status` can show the email next to each account without re-hitting the API:
+
+```
+$ claude-acc list
+Claude Code accounts:
+  ★ work       (default)  alice@anthropic.com  3d ago
+    personal              bob@anthropic.com    1h ago *
+
+$ claude-acc status
+Active account: work <alice@anthropic.com> (linked to my-project)
+```
+
+The `*` after an email means the OAuth token has rotated since the cache was written. Most often this is a routine OAuth refresh (identity unchanged) — but if you ran `claude auth login` directly between `doctor` runs, this is your reminder to re-verify. Run `claude-acc doctor` to refresh the cache.
+
 > **macOS only for now.** The Keychain hashing scheme is reverse-engineered from Claude Code's internals, so non-macOS platforms (where Claude Code uses libsecret / Credential Manager) aren't covered yet.
 
 ## Language

--- a/README.ru.md
+++ b/README.ru.md
@@ -196,6 +196,20 @@ $ claude-acc doctor
 
 Это исключительно read-only аудит — ничего не перехватывается, запуск `claude` не блокируется. Запускайте когда хочется убедиться, что за config dir стоит ожидаемая личность. Требует `security`, `curl`, `jq`, `shasum` (всё предустановлено на macOS); Rust-бинарник использует нативные `serde_json` и `sha2`, шеллаутит только `security` и `curl`.
 
+`doctor` ещё кэширует результат в `~/.claude-switch/accounts/<name>/.account-info.json`, чтобы `list` и `status` показывали email рядом с каждым аккаунтом без повторных API-запросов:
+
+```
+$ claude-acc list
+Аккаунты Claude Code:
+  ★ work       (по умолчанию)  alice@anthropic.com  3д назад
+    personal                   bob@anthropic.com    1ч назад *
+
+$ claude-acc status
+Активный аккаунт: work <alice@anthropic.com> (привязан к my-project)
+```
+
+`*` после email означает что OAuth-токен изменился с момента записи кэша. Чаще всего это рутинный refresh токена (identity та же) — но если вы запускали `claude auth login` напрямую между запусками `doctor`, это напоминание что стоит перепроверить. Запустите `claude-acc doctor`, чтобы обновить кэш.
+
 > **Пока только macOS.** Схема хеширования Keychain reverse-engineered из внутренностей Claude Code; на других платформах (где используется libsecret / Credential Manager) пока не работает.
 
 ## Язык

--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -420,11 +420,13 @@ _claude_acc_list() {
     fi
 
     _msg list_header
+    local suffix
     for acc in "${accounts[@]}"; do
+        suffix=$(_claude_acc_identity_suffix "$acc")
         if [[ "$acc" == "$default_acc" ]]; then
-            echo "  ★ $acc  $(_msg list_default)"
+            echo "  ★ $acc  $(_msg list_default)$suffix"
         else
-            echo "    $acc"
+            echo "    $acc$suffix"
         fi
     done
 }
@@ -650,7 +652,13 @@ _claude_acc_status() {
     fi
 
     if [[ -n "$account" ]]; then
-        _msg status_active "$account" "$source_info"
+        local label="$account" email drift
+        email=$(_claude_acc_cache_email "$account")
+        if [[ -n "$email" ]]; then
+            drift=$(_claude_acc_cache_drift_marker "$account")
+            label="$account <${email}${drift}>"
+        fi
+        _msg status_active "$label" "$source_info"
     else
         _msg status_standard
     fi
@@ -706,7 +714,7 @@ _claude_acc_token() {
     jq -r '.claudeAiOauth.accessToken // empty' "$acc_dir/.credentials.json" 2>/dev/null
 }
 
-# Echoes "<email>\t<uuid>" or empty on failure.
+# Echoes "<email>\t<uuid>\t<org>" or empty on failure.
 _claude_acc_identity() {
     local token="$1"
     [[ -z "$token" ]] && return 1
@@ -714,7 +722,99 @@ _claude_acc_identity() {
         -H "Authorization: Bearer $token" \
         -H "anthropic-beta: oauth-2025-04-20" \
         https://api.anthropic.com/api/oauth/profile 2>/dev/null \
-        | jq -r '"\(.account.email // "<unknown>")\t\(.account.uuid // "<unknown>")"' 2>/dev/null
+        | jq -r '"\(.account.email // "<unknown>")\t\(.account.uuid // "<unknown>")\t\(.organization.name // "")"' 2>/dev/null
+}
+
+# sha256(token)[0:16] — used as cache invalidation signal.
+_claude_acc_token_hash() {
+    local token="$1"
+    [[ -z "$token" ]] && return 1
+    printf '%s' "$token" | shasum -a 256 2>/dev/null | cut -c1-16
+}
+
+_claude_acc_cache_path() {
+    echo "$1/.account-info.json"
+}
+
+_claude_acc_write_cache() {
+    local acc_dir="$1" email="$2" uuid="$3" org="$4" token="$5"
+    local now hash cache
+    now=$(date +%s)
+    hash=$(_claude_acc_token_hash "$token")
+    cache=$(_claude_acc_cache_path "$acc_dir")
+    jq -n \
+        --arg email "$email" \
+        --arg uuid "$uuid" \
+        --arg org "$org" \
+        --argjson fetched_at "$now" \
+        --arg token_hash "$hash" \
+        '{email:$email, uuid:$uuid, org:$org, fetched_at:$fetched_at, token_hash:$token_hash}' \
+        > "$cache" 2>/dev/null
+}
+
+_claude_acc_cache_email() {
+    local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$1"
+    jq -r '.email // empty' "$(_claude_acc_cache_path "$acc_dir")" 2>/dev/null
+}
+
+# Echoes seconds elapsed since cache write, or empty if no/invalid cache.
+_claude_acc_cache_age() {
+    local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$1"
+    local fetched now
+    fetched=$(jq -r '.fetched_at // empty' "$(_claude_acc_cache_path "$acc_dir")" 2>/dev/null)
+    [[ -z "$fetched" || "$fetched" == "null" ]] && return 1
+    now=$(date +%s)
+    (( fetched > now )) && return 1
+    echo $(( now - fetched ))
+}
+
+# Prints " *" when current keychain token differs from the one cached at
+# last `doctor` run. Empty otherwise (including: no cache, no current
+# token, no token_hash field — i.e. when we can't compare safely).
+_claude_acc_cache_drift_marker() {
+    local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$1"
+    local cached current
+    cached=$(jq -r '.token_hash // empty' "$(_claude_acc_cache_path "$acc_dir")" 2>/dev/null)
+    [[ -z "$cached" || "$cached" == "null" ]] && return 0
+    current=$(_claude_acc_token_hash "$(_claude_acc_token "$acc_dir")")
+    [[ -z "$current" ]] && return 0
+    [[ "$cached" != "$current" ]] && printf ' *'
+}
+
+# Format a seconds count like 0/45/3600/86400 → "just now"/"45m ago"/"1h ago"/"1d ago".
+# Locale follows _claude_acc_lang.
+_claude_acc_relative_time() {
+    local secs="$1" lang n unit
+    lang=$(_claude_acc_lang)
+    if (( secs < 60 )); then
+        [[ "$lang" == "ru" ]] && echo "только что" || echo "just now"
+        return
+    fi
+    if   (( secs < 3600 ));     then n=$(( secs / 60 ));      [[ "$lang" == "ru" ]] && unit="м"   || unit="m"
+    elif (( secs < 86400 ));    then n=$(( secs / 3600 ));    [[ "$lang" == "ru" ]] && unit="ч"   || unit="h"
+    elif (( secs < 604800 ));   then n=$(( secs / 86400 ));   [[ "$lang" == "ru" ]] && unit="д"   || unit="d"
+    elif (( secs < 2592000 ));  then n=$(( secs / 604800 ));  [[ "$lang" == "ru" ]] && unit="н"   || unit="w"
+    elif (( secs < 31536000 )); then n=$(( secs / 2592000 )); [[ "$lang" == "ru" ]] && unit="мес" || unit="mo"
+    else                             n=$(( secs / 31536000 ));[[ "$lang" == "ru" ]] && unit="г"   || unit="y"
+    fi
+    if [[ "$lang" == "ru" ]]; then echo "${n}${unit} назад"; else echo "${n}${unit} ago"; fi
+}
+
+# Rendered "  email  3d ago" / "  email  3d ago *" / "" suffix for list/status.
+_claude_acc_identity_suffix() {
+    local name="$1" email when secs drift
+    email=$(_claude_acc_cache_email "$name")
+    [[ -z "$email" ]] && return 0
+    secs=$(_claude_acc_cache_age "$name")
+    if [[ -n "$secs" ]]; then
+        when=$(_claude_acc_relative_time "$secs")
+    fi
+    drift=$(_claude_acc_cache_drift_marker "$name")
+    if [[ -n "$when" ]]; then
+        printf '  %s  %s%s' "$email" "$when" "$drift"
+    else
+        printf '  %s%s' "$email" "$drift"
+    fi
 }
 
 _claude_acc_doctor() {
@@ -740,7 +840,7 @@ _claude_acc_doctor() {
         (( ${#acc} > width )) && width=${#acc}
     done
 
-    local healthy=0 token identity email uuid
+    local healthy=0 token identity email uuid org rest
     for acc in "${accounts[@]}"; do
         local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$acc"
         token=$(_claude_acc_token "$acc_dir")
@@ -754,7 +854,11 @@ _claude_acc_doctor() {
             continue
         fi
         email="${identity%%	*}"
-        uuid="${identity#*	}"
+        rest="${identity#*	}"
+        uuid="${rest%%	*}"
+        org="${rest#*	}"
+        [[ "$org" == "$rest" ]] && org=""
+        _claude_acc_write_cache "$acc_dir" "$email" "$uuid" "$org" "$token"
         printf "  ✓ %-${width}s  %s  uuid=%s\n" "$acc" "$email" "$uuid"
         (( healthy++ ))
     done

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,5 +1,6 @@
 use crate::config::AppConfig;
 use crate::i18n::{I18n, Msg};
+use crate::identity;
 
 pub fn run(config: &AppConfig, i18n: &I18n) {
     let default_acc = config.get_default().ok().flatten();
@@ -12,10 +13,45 @@ pub fn run(config: &AppConfig, i18n: &I18n) {
 
     i18n.print(Msg::ListHeader);
     for acc in &accounts {
+        let acc_dir = config.account_path(acc);
+        let info_suffix = identity_suffix(&acc_dir, i18n);
         if Some(acc.as_str()) == default_acc.as_deref() {
-            println!("  ★ {}  {}", acc, i18n.msg(Msg::ListDefault));
+            println!("  ★ {}  {}{}", acc, i18n.msg(Msg::ListDefault), info_suffix);
         } else {
-            println!("    {}", acc);
+            println!("    {}{}", acc, info_suffix);
         }
+    }
+}
+
+/// Returns "  email  3d ago" or "  email  3d ago *" if cached, else "".
+/// `*` means current keychain token differs from the one cached at last
+/// `doctor` run — usually a routine OAuth refresh, but could indicate a
+/// silent re-auth. README has the full explanation.
+fn identity_suffix(acc_dir: &std::path::Path, i18n: &I18n) -> String {
+    let Some(cache) = identity::read_cache(acc_dir) else {
+        return String::new();
+    };
+    let email = match cache.email {
+        Some(e) => e,
+        None => return String::new(),
+    };
+    let when = cache
+        .fetched_at
+        .and_then(identity::seconds_since)
+        .map(|secs| i18n.msg(Msg::RelativeTime(secs)))
+        .unwrap_or_default();
+
+    let drift = match (
+        cache.token_hash.as_deref(),
+        identity::current_token_hash(acc_dir),
+    ) {
+        (Some(cached), Some(current)) if cached != current => " *",
+        _ => "",
+    };
+
+    if when.is_empty() {
+        format!("  {}{}", email, drift)
+    } else {
+        format!("  {}  {}{}", email, when, drift)
     }
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,5 +1,6 @@
 use crate::config::AppConfig;
 use crate::i18n::{I18n, Msg};
+use crate::identity;
 use crate::resolve;
 
 pub fn run(config: &AppConfig, i18n: &I18n) {
@@ -15,16 +16,37 @@ pub fn run(config: &AppConfig, i18n: &I18n) {
                 .and_then(|n| n.to_str())
                 .unwrap_or(ld);
             let info = i18n.msg(Msg::StatusLinked(dir_name.to_string()));
-            i18n.print(Msg::StatusActive(acc.clone(), info));
+            i18n.print(Msg::StatusActive(label(config, acc), info));
             return;
         }
     }
 
     if let Ok(Some(ref acc)) = config.get_default() {
         let info = i18n.msg(Msg::StatusDefault);
-        i18n.print(Msg::StatusActive(acc.clone(), info));
+        i18n.print(Msg::StatusActive(label(config, acc), info));
         return;
     }
 
     i18n.print(Msg::StatusStandard);
+}
+
+/// "<acc>" or "<acc> <email>" or "<acc> <email *>" depending on what's
+/// cached. The trailing `*` flags drift between cached and current
+/// keychain token (see commands/list.rs for the full convention).
+fn label(config: &AppConfig, acc: &str) -> String {
+    let acc_dir = config.account_path(acc);
+    let Some(cache) = identity::read_cache(&acc_dir) else {
+        return acc.to_string();
+    };
+    let Some(email) = cache.email else {
+        return acc.to_string();
+    };
+    let drift = match (
+        cache.token_hash.as_deref(),
+        identity::current_token_hash(&acc_dir),
+    ) {
+        (Some(cached), Some(current)) if cached != current => " *",
+        _ => "",
+    };
+    format!("{} <{}{}>", acc, email, drift)
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -200,6 +200,7 @@ impl I18n {
             }
 
             // doctor
+            (Msg::RelativeTime(secs), lang) => relative_time(secs, lang),
             (Msg::DoctorHeader(n), Lang::En) => format!("Auditing {} account(s):", n),
             (Msg::DoctorHeader(n), Lang::Ru) => format!("Проверка {} аккаунт(ов):", n),
             (Msg::DoctorNoToken(ref name), Lang::En) => {
@@ -282,4 +283,31 @@ pub enum Msg {
     DoctorOffline,
     DoctorAllOk,
     DoctorPartial(usize, usize),
+    RelativeTime(u64),
+}
+
+fn relative_time(secs: u64, lang: Lang) -> String {
+    if secs < 60 {
+        return match lang {
+            Lang::En => "just now".to_string(),
+            Lang::Ru => "только что".to_string(),
+        };
+    }
+    let (n, unit_en, unit_ru) = if secs < 3600 {
+        (secs / 60, "m", "м")
+    } else if secs < 86400 {
+        (secs / 3600, "h", "ч")
+    } else if secs < 604800 {
+        (secs / 86400, "d", "д")
+    } else if secs < 2592000 {
+        (secs / 604800, "w", "н")
+    } else if secs < 31536000 {
+        (secs / 2592000, "mo", "мес")
+    } else {
+        (secs / 31536000, "y", "г")
+    };
+    match lang {
+        Lang::En => format!("{}{} ago", n, unit_en),
+        Lang::Ru => format!("{}{} назад", n, unit_ru),
+    }
 }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -14,8 +14,9 @@
 // might change.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use sha2::{Digest, Sha256};
 
@@ -37,7 +38,13 @@ pub fn audit_account(acc_dir: &Path) -> AuditResult {
         return AuditResult::NoToken;
     };
     match fetch_profile(&token) {
-        Some(p) => AuditResult::Ok(p),
+        Some(p) => {
+            // Side effect: refresh the cache so list/status can show the
+            // identity without re-hitting the API. Errors here are silent —
+            // doctor's own output is the source of truth for this run.
+            let _ = write_cache(acc_dir, &p, &token);
+            AuditResult::Ok(p)
+        }
         None => AuditResult::Offline,
     }
 }
@@ -88,6 +95,93 @@ fn extract_access_token(raw: &str) -> Option<String> {
         .get("accessToken")?
         .as_str()
         .map(|s| s.to_string())
+}
+
+// --- Cache (.account-info.json) ---
+//
+// Written by `doctor` on every successful API audit. Read by `list` and
+// `status` so they can show the email / fetched_at without hitting the API.
+//
+// `token_hash` is sha256(access_token) truncated to 16 hex chars. Used as a
+// soft signal: if the current keychain token's hash matches what we cached,
+// the cache is "stable since last verify". If it differs, the token has
+// rotated since cache write — which is most often a routine OAuth refresh
+// (identity unchanged) but could also be a re-auth to a different account.
+// Callers display a `*` marker on mismatch and let the user decide whether
+// to re-run `doctor`.
+
+pub struct CachedInfo {
+    pub email: Option<String>,
+    #[allow(dead_code)] // serialized for doctor's stable-uuid comparison in future phases
+    pub uuid: Option<String>,
+    #[allow(dead_code)]
+    pub org: Option<String>,
+    pub fetched_at: Option<u64>,
+    pub token_hash: Option<String>,
+}
+
+fn cache_path(acc_dir: &Path) -> PathBuf {
+    acc_dir.join(".account-info.json")
+}
+
+pub fn write_cache(acc_dir: &Path, profile: &Profile, token: &str) -> std::io::Result<()> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let body = serde_json::json!({
+        "email": profile.email,
+        "uuid": profile.uuid,
+        "org": profile.organization,
+        "fetched_at": now,
+        "token_hash": token_hash(token),
+    });
+    let serialized = serde_json::to_string_pretty(&body).map_err(std::io::Error::other)?;
+    fs::write(cache_path(acc_dir), serialized)
+}
+
+pub fn read_cache(acc_dir: &Path) -> Option<CachedInfo> {
+    let content = fs::read_to_string(cache_path(acc_dir)).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&content).ok()?;
+    Some(CachedInfo {
+        email: v.get("email").and_then(|x| x.as_str()).map(String::from),
+        uuid: v.get("uuid").and_then(|x| x.as_str()).map(String::from),
+        org: v.get("org").and_then(|x| x.as_str()).map(String::from),
+        fetched_at: v.get("fetched_at").and_then(|x| x.as_u64()),
+        token_hash: v
+            .get("token_hash")
+            .and_then(|x| x.as_str())
+            .map(String::from),
+    })
+}
+
+pub fn token_hash(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    let digest = hasher.finalize();
+    digest
+        .iter()
+        .take(8)
+        .map(|b| format!("{:02x}", b))
+        .collect()
+}
+
+/// Hash of the *current* keychain token for `acc_dir`, for comparing against
+/// `CachedInfo::token_hash`. Returns `None` if no keychain token (e.g. not on
+/// macOS, no Claude Code login, or `security` failed) — caller treats `None`
+/// as "can't verify, skip the marker".
+pub fn current_token_hash(acc_dir: &Path) -> Option<String> {
+    read_token(acc_dir).map(|t| token_hash(&t))
+}
+
+/// Seconds elapsed since `fetched_at`. Returns `None` if the timestamp looks
+/// invalid (in the future, or epoch).
+pub fn seconds_since(fetched_at: u64) -> Option<u64> {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+    if fetched_at == 0 || fetched_at > now {
+        return None;
+    }
+    Some(now - fetched_at)
 }
 
 fn whoami_short() -> Option<String> {


### PR DESCRIPTION
## Summary

Extends `doctor` (#14) to also cache the audit result, and surfaces the email in `list` / `status` output. Hybrid approach to staleness: always show the cached email + relative timestamp, but flag with a `*` marker when the current keychain token differs from the one captured at audit time.

```
$ claude-acc list
Claude Code accounts:
  ★ work       (default)  alice@anthropic.com  3d ago
    personal              bob@anthropic.com    1h ago *

$ claude-acc status
Active account: work <alice@anthropic.com> (linked to my-project)
```

## Why hybrid

We discussed three approaches in chat:

- **A — show timestamp, accept stale risk.** Simple, but if you re-auth via `claude auth login` directly, list/status will silently show the old email.
- **B — invalidate cache on token-hash mismatch.** Catches the swap but produces false-positive "no info" after every routine OAuth refresh, forcing constant `doctor` re-runs.
- **A+B hybrid (this PR).** Always show cached email; mark with `*` when token has rotated. Refreshes show `*` (visual noise, easily ignored). Real identity swap also shows `*` and prompts re-verification. Functionality never regresses.

## Implementation

- **Cache file** at `~/.claude-switch/accounts/<name>/.account-info.json`:
  ```json
  {
    "email": "alice@anthropic.com",
    "uuid": "aa6c22d5-...",
    "org": "Anthropic",
    "fetched_at": 1714900000,
    "token_hash": "287b7e06d52499ee"
  }
  ```
  `token_hash` is `sha256(access_token)[0:16]`.
- **Rust** — new `identity::write_cache` / `read_cache` / `current_token_hash` / `seconds_since`. `audit_account` writes the cache on success as a side effect, so `doctor` itself didn't need to change. `list.rs` and `status.rs` gained a small `identity_suffix` / `label` helper that reads the cache and formats the suffix.
- **Shell** — mirrors the same logic in `_claude_acc_write_cache`, `_claude_acc_cache_email`, `_claude_acc_cache_age`, `_claude_acc_cache_drift_marker`, `_claude_acc_relative_time` (locale-aware), `_claude_acc_identity_suffix`.
- **i18n** — new `Msg::RelativeTime(secs)` for both en + ru ("3d ago" / "3д назад"). Shell's `_claude_acc_relative_time` handles ru/en switching the same way.
- **README** — both en and ru got extended `doctor` sections covering the new list/status output and the `*` convention.

## Test plan

Verified locally on macOS:
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --release` — all clean
- [x] All four shell files parse (`zsh -n` / `bash -n`)
- [x] **No cache:** list/status fall back to old behaviour, no email shown
- [x] **After doctor:** list shows `email  just now`, status shows `<email>` inline
- [x] **Drift:** corrupted `token_hash` in cache → list/status show ` *` next to email; running `doctor` clears the marker
- [x] Both Rust and shell implementations produce identical output for the same account

`feat:` prefix → next release-please run will bump 0.3.0 → 0.4.0.