### PR TITLE
feat: surface ~/.claude/ standard identity in doctor / list / status / default

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,17 +197,23 @@ Auditing 2 account(s):
 
 It's purely a read-only audit — nothing is intercepted, no `claude` invocation is gated. Run it whenever you want to confirm a config dir is bound to the identity you expect. Requires `security`, `curl`, `jq`, and `shasum` (all preinstalled on macOS); the Rust binary uses native `serde_json` and `sha2` instead and only shells out to `security` and `curl`.
 
-`doctor` also caches the result to `~/.claude-switch/accounts/<name>/.account-info.json` so `list` and `status` can show the email next to each account without re-hitting the API:
+`doctor` also caches the result to `~/.claude-switch/accounts/<name>/.account-info.json` so `list`, `status`, and `default` can show the email next to each account without re-hitting the API:
 
 ```
 $ claude-acc list
 Claude Code accounts:
-  ★ work       (default)  alice@anthropic.com  3d ago
-    personal              bob@anthropic.com    1h ago *
+  ★ work       (default)  alice@anthropic.com   3d ago
+    personal              bob@anthropic.com     1h ago *
+    ~/.claude/            charlie@personal.com  3d ago    (standard)
 
 $ claude-acc status
 Active account: work <alice@anthropic.com> (linked to my-project)
+
+$ claude-acc default
+Default: work <alice@anthropic.com>
 ```
+
+`doctor` audits the standard `~/.claude/` config too (the unmanaged identity used when no link / configured default applies). Its cache lives at `~/.claude-switch/default.account-info.json`. The `~/.claude/` row appears in `list` only after you've actually logged into Claude Code with the standard config (or after `doctor` has cached an identity for it).
 
 The `*` after an email means the OAuth token has rotated since the cache was written. Most often this is a routine OAuth refresh (identity unchanged) — but if you ran `claude auth login` directly between `doctor` runs, this is your reminder to re-verify. Run `claude-acc doctor` to refresh the cache.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -196,17 +196,23 @@ $ claude-acc doctor
 
 Это исключительно read-only аудит — ничего не перехватывается, запуск `claude` не блокируется. Запускайте когда хочется убедиться, что за config dir стоит ожидаемая личность. Требует `security`, `curl`, `jq`, `shasum` (всё предустановлено на macOS); Rust-бинарник использует нативные `serde_json` и `sha2`, шеллаутит только `security` и `curl`.
 
-`doctor` ещё кэширует результат в `~/.claude-switch/accounts/<name>/.account-info.json`, чтобы `list` и `status` показывали email рядом с каждым аккаунтом без повторных API-запросов:
+`doctor` ещё кэширует результат в `~/.claude-switch/accounts/<name>/.account-info.json`, чтобы `list`, `status` и `default` показывали email рядом с каждым аккаунтом без повторных API-запросов:
 
 ```
 $ claude-acc list
 Аккаунты Claude Code:
-  ★ work       (по умолчанию)  alice@anthropic.com  3д назад
-    personal                   bob@anthropic.com    1ч назад *
+  ★ work       (по умолчанию)  alice@anthropic.com   3д назад
+    personal                   bob@anthropic.com     1ч назад *
+    ~/.claude/                 charlie@personal.com  3д назад    (стандартный)
 
 $ claude-acc status
 Активный аккаунт: work <alice@anthropic.com> (привязан к my-project)
+
+$ claude-acc default
+По умолчанию: work <alice@anthropic.com>
 ```
+
+`doctor` аудитит и стандартный `~/.claude/` (неуправляемая личность, к которой claude обращается когда нет ни link'а, ни настроенного default'а). Его кэш лежит в `~/.claude-switch/default.account-info.json`. Строка `~/.claude/` появляется в `list` только если вы реально залогинены в Claude Code со стандартным config-dir (или если `doctor` уже закэшировал identity для него).
 
 `*` после email означает что OAuth-токен изменился с момента записи кэша. Чаще всего это рутинный refresh токена (identity та же) — но если вы запускали `claude auth login` напрямую между запусками `doctor`, это напоминание что стоит перепроверить. Запустите `claude-acc doctor`, чтобы обновить кэш.
 

--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -63,6 +63,7 @@ _claude_msg_en=(
     list_empty          "No accounts. Add one: claude-acc add <name>"
     list_header         "Claude Code accounts:"
     list_default        "(default)"
+    list_standard       "(standard)"
     add_usage           "Usage: claude-acc add <name>"
     add_example         "Example: claude-acc add personal"
     add_exists          "Account '%s' already exists."
@@ -129,6 +130,7 @@ _claude_msg_ru=(
     list_empty          "Нет аккаунтов. Добавьте: claude-acc add <name>"
     list_header         "Аккаунты Claude Code:"
     list_default        "(по умолчанию)"
+    list_standard       "(стандартный)"
     add_usage           "Использование: claude-acc add <name>"
     add_example         "Пример:        claude-acc add personal"
     add_exists          "Аккаунт '%s' уже существует."
@@ -429,6 +431,16 @@ _claude_acc_list() {
             echo "    $acc$suffix"
         fi
     done
+
+    # Unmanaged ~/.claude/ — show row only if there's a real keychain login
+    # there OR an existing default cache (i.e. doctor has audited it before).
+    local std_token std_cache
+    std_token=$(_claude_acc_token "$(_claude_acc_default_token_dir)")
+    std_cache=$(_claude_acc_default_cache_path)
+    if [[ -n "$std_token" || -f "$std_cache" ]]; then
+        suffix=$(_claude_acc_default_suffix)
+        echo "    ~/.claude/$suffix  $(_msg list_standard)"
+    fi
 }
 
 _claude_acc_add() {
@@ -537,10 +549,13 @@ _claude_acc_remove() {
 _claude_acc_default() {
     local name="$1"
     if [[ -z "$name" ]]; then
-        local current
+        local current email label
         current=$(_claude_default_account)
         if [[ -n "$current" ]]; then
-            _msg default_current "$current"
+            label="$current"
+            email=$(_claude_acc_cache_email "$current")
+            [[ -n "$email" ]] && label="$current <$email>"
+            _msg default_current "$label"
         else
             _msg default_standard
         fi
@@ -660,7 +675,15 @@ _claude_acc_status() {
         fi
         _msg status_active "$label" "$source_info"
     else
-        _msg status_standard
+        # Standard ~/.claude/ — surface email if `doctor` has cached one.
+        local std_email std_drift
+        std_email=$(_claude_acc_default_email)
+        if [[ -n "$std_email" ]]; then
+            std_drift=$(_claude_acc_default_drift_marker)
+            _msg status_active "~/.claude/ <${std_email}${std_drift}>" "$(_msg list_standard)"
+        else
+            _msg status_standard
+        fi
     fi
 }
 
@@ -736,12 +759,21 @@ _claude_acc_cache_path() {
     echo "$1/.account-info.json"
 }
 
+# Cache for the unmanaged ~/.claude/ ("standard / default") config dir.
+# Lives in our switch dir, never inside ~/.claude/ itself.
+_claude_acc_default_cache_path() {
+    echo "$CLAUDE_SWITCH_DIR/default.account-info.json"
+}
+
+_claude_acc_default_token_dir() {
+    echo "$HOME/.claude"
+}
+
 _claude_acc_write_cache() {
-    local acc_dir="$1" email="$2" uuid="$3" org="$4" token="$5"
-    local now hash cache
+    local cache="$1" email="$2" uuid="$3" org="$4" token="$5"
+    local now hash
     now=$(date +%s)
     hash=$(_claude_acc_token_hash "$token")
-    cache=$(_claude_acc_cache_path "$acc_dir")
     jq -n \
         --arg email "$email" \
         --arg uuid "$uuid" \
@@ -800,6 +832,44 @@ _claude_acc_relative_time() {
     if [[ "$lang" == "ru" ]]; then echo "${n}${unit} назад"; else echo "${n}${unit} ago"; fi
 }
 
+_claude_acc_default_email() {
+    jq -r '.email // empty' "$(_claude_acc_default_cache_path)" 2>/dev/null
+}
+
+_claude_acc_default_drift_marker() {
+    local cached current
+    cached=$(jq -r '.token_hash // empty' "$(_claude_acc_default_cache_path)" 2>/dev/null)
+    [[ -z "$cached" || "$cached" == "null" ]] && return 0
+    current=$(_claude_acc_token_hash "$(_claude_acc_token "$(_claude_acc_default_token_dir)")")
+    [[ -z "$current" ]] && return 0
+    [[ "$cached" != "$current" ]] && printf ' *'
+}
+
+# Suffix for the unmanaged ~/.claude/ row in `list`. Empty if no cache or
+# no email; otherwise "  email  3d ago" with optional ` *` drift marker.
+_claude_acc_default_suffix() {
+    local cache email fetched now secs when drift
+    cache=$(_claude_acc_default_cache_path)
+    [[ ! -f "$cache" ]] && return 0
+    email=$(jq -r '.email // empty' "$cache" 2>/dev/null)
+    [[ -z "$email" ]] && return 0
+    fetched=$(jq -r '.fetched_at // empty' "$cache" 2>/dev/null)
+    when=""
+    if [[ -n "$fetched" && "$fetched" != "null" ]]; then
+        now=$(date +%s)
+        if (( fetched <= now )); then
+            secs=$(( now - fetched ))
+            when=$(_claude_acc_relative_time "$secs")
+        fi
+    fi
+    drift=$(_claude_acc_default_drift_marker)
+    if [[ -n "$when" ]]; then
+        printf '  %s  %s%s' "$email" "$when" "$drift"
+    else
+        printf '  %s%s' "$email" "$drift"
+    fi
+}
+
 # Rendered "  email  3d ago" / "  email  3d ago *" / "" suffix for list/status.
 _claude_acc_identity_suffix() {
     local name="$1" email when secs drift
@@ -827,20 +897,30 @@ _claude_acc_doctor() {
     done
 
     local accounts=("$CLAUDE_SWITCH_ACCOUNTS_DIR"/*(N:t))
-    if [[ ${#accounts} -eq 0 ]]; then
+    local standard_label="~/.claude/"
+    local standard_dir
+    standard_dir=$(_claude_acc_default_token_dir)
+    local standard_present=0
+    [[ -n "$(_claude_acc_token "$standard_dir")" ]] && standard_present=1
+
+    if (( ${#accounts} == 0 && standard_present == 0 )); then
         _msg list_empty
         return 0
     fi
 
-    _msg doctor_header "${#accounts}"
+    local total=$(( ${#accounts} + standard_present ))
+    _msg doctor_header "$total"
 
     # Compute label width for aligned output.
     local width=0 acc
     for acc in "${accounts[@]}"; do
         (( ${#acc} > width )) && width=${#acc}
     done
+    if (( standard_present )); then
+        (( ${#standard_label} > width )) && width=${#standard_label}
+    fi
 
-    local healthy=0 token identity email uuid org rest
+    local healthy=0 token identity email uuid org rest cache_path
     for acc in "${accounts[@]}"; do
         local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$acc"
         token=$(_claude_acc_token "$acc_dir")
@@ -858,17 +938,37 @@ _claude_acc_doctor() {
         uuid="${rest%%	*}"
         org="${rest#*	}"
         [[ "$org" == "$rest" ]] && org=""
-        _claude_acc_write_cache "$acc_dir" "$email" "$uuid" "$org" "$token"
+        cache_path=$(_claude_acc_cache_path "$acc_dir")
+        _claude_acc_write_cache "$cache_path" "$email" "$uuid" "$org" "$token"
         printf "  ✓ %-${width}s  %s  uuid=%s\n" "$acc" "$email" "$uuid"
         (( healthy++ ))
     done
 
+    if (( standard_present )); then
+        token=$(_claude_acc_token "$standard_dir")
+        identity=$(_claude_acc_identity "$token")
+        if [[ -z "$identity" ]]; then
+            printf "  ? %-${width}s  %s\n" "$standard_label" "$(_msg doctor_offline)"
+        else
+            email="${identity%%	*}"
+            rest="${identity#*	}"
+            uuid="${rest%%	*}"
+            org="${rest#*	}"
+            [[ "$org" == "$rest" ]] && org=""
+            cache_path=$(_claude_acc_default_cache_path)
+            _claude_acc_write_cache "$cache_path" "$email" "$uuid" "$org" "$token"
+            printf "  ✓ %-${width}s  %s  uuid=%s  (%s)\n" \
+                "$standard_label" "$email" "$uuid" "$(_msg list_standard)"
+            (( healthy++ ))
+        fi
+    fi
+
     echo ""
-    if (( healthy == ${#accounts} )); then
+    if (( healthy == total )); then
         _msg doctor_all_ok
         return 0
     else
-        _msg doctor_partial "$healthy" "${#accounts}"
+        _msg doctor_partial "$healthy" "$total"
         return 1
     fi
 }

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -1,10 +1,18 @@
 use crate::config::{AppConfig, validate_name};
 use crate::i18n::{I18n, Msg};
+use crate::identity;
 
 pub fn run(config: &AppConfig, i18n: &I18n, name: Option<&str>) {
     match name {
         None => match config.get_default().ok().flatten() {
-            Some(current) => i18n.print(Msg::DefaultCurrent(current)),
+            Some(current) => {
+                let acc_dir = config.account_path(&current);
+                let label = match identity::read_cache(&acc_dir).and_then(|c| c.email) {
+                    Some(email) => format!("{} <{}>", current, email),
+                    None => current,
+                };
+                i18n.print(Msg::DefaultCurrent(label));
+            }
             None => i18n.print(Msg::DefaultStandard),
         },
         Some("default") => {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -7,14 +7,33 @@ pub fn run(config: &AppConfig, i18n: &I18n) -> i32 {
         Ok(v) => v,
         Err(_) => return 1,
     };
-    if accounts.is_empty() {
+
+    // The standard "default" line shows up if a login exists in ~/.claude/.
+    // Otherwise it would just print noise on every doctor run, so we hide it
+    // when there's no token there.
+    let standard_label = "~/.claude/";
+    let standard_present = identity::standard_token_dir()
+        .map(|d| identity::current_token_hash(&d).is_some())
+        .unwrap_or(false);
+
+    if accounts.is_empty() && !standard_present {
         i18n.print(Msg::ListEmpty);
         return 0;
     }
 
-    i18n.print(Msg::DoctorHeader(accounts.len()));
+    let total = accounts.len() + if standard_present { 1 } else { 0 };
+    i18n.print(Msg::DoctorHeader(total));
 
-    let label_w = accounts.iter().map(|a| a.len()).max().unwrap_or(0);
+    let label_w = accounts
+        .iter()
+        .map(|a| a.len())
+        .chain(std::iter::once(if standard_present {
+            standard_label.len()
+        } else {
+            0
+        }))
+        .max()
+        .unwrap_or(0);
     let mut healthy = 0usize;
 
     for acc in &accounts {
@@ -41,12 +60,43 @@ pub fn run(config: &AppConfig, i18n: &I18n) -> i32 {
         }
     }
 
+    if standard_present {
+        let pad = " ".repeat(label_w.saturating_sub(standard_label.len()));
+        match identity::audit_default(&config.base_dir) {
+            AuditResult::Ok(p) => {
+                healthy += 1;
+                let email = p.email.as_deref().unwrap_or("<unknown>");
+                let uuid = p.uuid.as_deref().unwrap_or("<unknown>");
+                println!(
+                    "  ✓ {}{}  {}  uuid={}  ({})",
+                    standard_label,
+                    pad,
+                    email,
+                    uuid,
+                    i18n.msg(Msg::ListStandard)
+                );
+            }
+            AuditResult::Offline => {
+                println!(
+                    "  ? {}{}  {}",
+                    standard_label,
+                    pad,
+                    i18n.msg(Msg::DoctorOffline)
+                );
+            }
+            AuditResult::NoToken => {
+                // standard_present was true above, but the token could
+                // have disappeared between the two reads — fall through.
+            }
+        }
+    }
+
     println!();
-    if healthy == accounts.len() {
+    if healthy == total {
         i18n.print(Msg::DoctorAllOk);
         0
     } else {
-        i18n.print(Msg::DoctorPartial(healthy, accounts.len()));
+        i18n.print(Msg::DoctorPartial(healthy, total));
         1
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,39 +1,76 @@
+use std::path::Path;
+
 use crate::config::AppConfig;
 use crate::i18n::{I18n, Msg};
-use crate::identity;
+use crate::identity::{self, CachedInfo};
 
 pub fn run(config: &AppConfig, i18n: &I18n) {
     let default_acc = config.get_default().ok().flatten();
     let accounts = config.list_accounts().unwrap_or_default();
 
-    if accounts.is_empty() {
+    // Standard ~/.claude/ shows up only if the user has actually logged into
+    // the standard config — so empty installs don't get a phantom row.
+    let standard = identity::standard_token_dir();
+    let standard_logged_in = standard
+        .as_deref()
+        .and_then(identity::current_token_hash)
+        .is_some()
+        || identity::read_cache_at(&identity::default_cache_path(&config.base_dir)).is_some();
+
+    if accounts.is_empty() && !standard_logged_in {
         i18n.print(Msg::ListEmpty);
         return;
     }
 
     i18n.print(Msg::ListHeader);
+
     for acc in &accounts {
         let acc_dir = config.account_path(acc);
-        let info_suffix = identity_suffix(&acc_dir, i18n);
+        let cache = identity::read_cache(&acc_dir);
+        let info_suffix = cache_suffix(
+            cache.as_ref(),
+            Some(acc_dir.as_path()),
+            i18n,
+            /* skip_label */ "",
+        );
         if Some(acc.as_str()) == default_acc.as_deref() {
             println!("  ★ {}  {}{}", acc, i18n.msg(Msg::ListDefault), info_suffix);
         } else {
             println!("    {}{}", acc, info_suffix);
         }
     }
+
+    if standard_logged_in {
+        let cache_path = identity::default_cache_path(&config.base_dir);
+        let cache = identity::read_cache_at(&cache_path);
+        let suffix = cache_suffix(
+            cache.as_ref(),
+            standard.as_deref(),
+            i18n,
+            &format!("  {}", i18n.msg(Msg::ListStandard)),
+        );
+        println!("    ~/.claude/{}", suffix);
+    }
 }
 
-/// Returns "  email  3d ago" or "  email  3d ago *" if cached, else "".
-/// `*` means current keychain token differs from the one cached at last
-/// `doctor` run — usually a routine OAuth refresh, but could indicate a
-/// silent re-auth. README has the full explanation.
-fn identity_suffix(acc_dir: &std::path::Path, i18n: &I18n) -> String {
-    let Some(cache) = identity::read_cache(acc_dir) else {
-        return String::new();
+/// Returns "  email  3d ago [skip_label]" or "  email  3d ago * [skip_label]"
+/// if cache is present, else just `skip_label` if any.
+///
+/// `*` means current token at `token_dir` differs from the one cached at
+/// last `doctor` run (see README — usually a routine OAuth refresh).
+/// `skip_label` is appended after the time/marker, used by the standard row
+/// to add `(standard)`.
+fn cache_suffix(
+    cache: Option<&CachedInfo>,
+    token_dir: Option<&Path>,
+    i18n: &I18n,
+    skip_label: &str,
+) -> String {
+    let Some(cache) = cache else {
+        return skip_label.to_string();
     };
-    let email = match cache.email {
-        Some(e) => e,
-        None => return String::new(),
+    let Some(email) = cache.email.as_deref() else {
+        return skip_label.to_string();
     };
     let when = cache
         .fetched_at
@@ -43,15 +80,16 @@ fn identity_suffix(acc_dir: &std::path::Path, i18n: &I18n) -> String {
 
     let drift = match (
         cache.token_hash.as_deref(),
-        identity::current_token_hash(acc_dir),
+        token_dir.and_then(identity::current_token_hash),
     ) {
         (Some(cached), Some(current)) if cached != current => " *",
         _ => "",
     };
 
-    if when.is_empty() {
+    let body = if when.is_empty() {
         format!("  {}{}", email, drift)
     } else {
         format!("  {}  {}{}", email, when, drift)
-    }
+    };
+    format!("{}{}", body, skip_label)
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -27,7 +27,17 @@ pub fn run(config: &AppConfig, i18n: &I18n) {
         return;
     }
 
-    i18n.print(Msg::StatusStandard);
+    // Standard ~/.claude/ — show email if doctor cached one for it.
+    let standard_label = standard_label(config);
+    if standard_label != "~/.claude/" {
+        // Cache exists; format follows StatusActive for visual consistency.
+        i18n.print(Msg::StatusActive(
+            standard_label,
+            i18n.msg(Msg::ListStandard),
+        ));
+    } else {
+        i18n.print(Msg::StatusStandard);
+    }
 }
 
 /// "<acc>" or "<acc> <email>" or "<acc> <email *>" depending on what's
@@ -49,4 +59,25 @@ fn label(config: &AppConfig, acc: &str) -> String {
         _ => "",
     };
     format!("{} <{}{}>", acc, email, drift)
+}
+
+/// "~/.claude/" or "~/.claude/ <email>" or "~/.claude/ <email *>".
+fn standard_label(config: &AppConfig) -> String {
+    let cache_path = identity::default_cache_path(&config.base_dir);
+    let Some(cache) = identity::read_cache_at(&cache_path) else {
+        return "~/.claude/".to_string();
+    };
+    let Some(email) = cache.email else {
+        return "~/.claude/".to_string();
+    };
+    let drift = match (
+        cache.token_hash.as_deref(),
+        identity::standard_token_dir()
+            .as_deref()
+            .and_then(identity::current_token_hash),
+    ) {
+        (Some(cached), Some(current)) if cached != current => " *",
+        _ => "",
+    };
+    format!("~/.claude/ <{}{}>", email, drift)
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -46,6 +46,8 @@ impl I18n {
             (Msg::ListHeader, Lang::Ru) => s("Аккаунты Claude Code:"),
             (Msg::ListDefault, Lang::En) => s("(default)"),
             (Msg::ListDefault, Lang::Ru) => s("(по умолчанию)"),
+            (Msg::ListStandard, Lang::En) => s("(standard)"),
+            (Msg::ListStandard, Lang::Ru) => s("(стандартный)"),
 
             // add
             (Msg::AddExists(ref n), Lang::En) => format!("Account '{}' already exists.", n),
@@ -239,6 +241,7 @@ pub enum Msg {
     ListEmpty,
     ListHeader,
     ListDefault,
+    ListStandard,
     AddExists(String),
     AddCreated(String),
     AddDone,

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -34,7 +34,31 @@ pub enum AuditResult {
 }
 
 pub fn audit_account(acc_dir: &Path) -> AuditResult {
-    let Some(token) = read_token(acc_dir) else {
+    let cache = acc_dir.join(".account-info.json");
+    audit_at(acc_dir, &cache)
+}
+
+/// Audit the standard `~/.claude/` config dir — the un-managed identity that
+/// claude falls back to when no link / configured default applies. Cache lives
+/// inside our switch dir (`default.account-info.json`), never inside
+/// `~/.claude/` itself.
+pub fn audit_default(switch_dir: &Path) -> AuditResult {
+    let Some(claude_dir) = standard_token_dir() else {
+        return AuditResult::NoToken;
+    };
+    audit_at(&claude_dir, &default_cache_path(switch_dir))
+}
+
+pub fn standard_token_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".claude"))
+}
+
+pub fn default_cache_path(switch_dir: &Path) -> PathBuf {
+    switch_dir.join("default.account-info.json")
+}
+
+fn audit_at(token_dir: &Path, cache_path: &Path) -> AuditResult {
+    let Some(token) = read_token(token_dir) else {
         return AuditResult::NoToken;
     };
     match fetch_profile(&token) {
@@ -42,7 +66,7 @@ pub fn audit_account(acc_dir: &Path) -> AuditResult {
             // Side effect: refresh the cache so list/status can show the
             // identity without re-hitting the API. Errors here are silent —
             // doctor's own output is the source of truth for this run.
-            let _ = write_cache(acc_dir, &p, &token);
+            let _ = write_cache_at(cache_path, &p, &token);
             AuditResult::Ok(p)
         }
         None => AuditResult::Offline,
@@ -120,28 +144,12 @@ pub struct CachedInfo {
     pub token_hash: Option<String>,
 }
 
-fn cache_path(acc_dir: &Path) -> PathBuf {
-    acc_dir.join(".account-info.json")
-}
-
-pub fn write_cache(acc_dir: &Path, profile: &Profile, token: &str) -> std::io::Result<()> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    let body = serde_json::json!({
-        "email": profile.email,
-        "uuid": profile.uuid,
-        "org": profile.organization,
-        "fetched_at": now,
-        "token_hash": token_hash(token),
-    });
-    let serialized = serde_json::to_string_pretty(&body).map_err(std::io::Error::other)?;
-    fs::write(cache_path(acc_dir), serialized)
-}
-
 pub fn read_cache(acc_dir: &Path) -> Option<CachedInfo> {
-    let content = fs::read_to_string(cache_path(acc_dir)).ok()?;
+    read_cache_at(&acc_dir.join(".account-info.json"))
+}
+
+pub fn read_cache_at(path: &Path) -> Option<CachedInfo> {
+    let content = fs::read_to_string(path).ok()?;
     let v: serde_json::Value = serde_json::from_str(&content).ok()?;
     Some(CachedInfo {
         email: v.get("email").and_then(|x| x.as_str()).map(String::from),
@@ -155,6 +163,22 @@ pub fn read_cache(acc_dir: &Path) -> Option<CachedInfo> {
     })
 }
 
+fn write_cache_at(path: &Path, profile: &Profile, token: &str) -> std::io::Result<()> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let body = serde_json::json!({
+        "email": profile.email,
+        "uuid": profile.uuid,
+        "org": profile.organization,
+        "fetched_at": now,
+        "token_hash": token_hash(token),
+    });
+    let serialized = serde_json::to_string_pretty(&body).map_err(std::io::Error::other)?;
+    fs::write(path, serialized)
+}
+
 pub fn token_hash(token: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
@@ -166,12 +190,13 @@ pub fn token_hash(token: &str) -> String {
         .collect()
 }
 
-/// Hash of the *current* keychain token for `acc_dir`, for comparing against
-/// `CachedInfo::token_hash`. Returns `None` if no keychain token (e.g. not on
-/// macOS, no Claude Code login, or `security` failed) — caller treats `None`
-/// as "can't verify, skip the marker".
-pub fn current_token_hash(acc_dir: &Path) -> Option<String> {
-    read_token(acc_dir).map(|t| token_hash(&t))
+/// Hash of the *current* keychain token for `token_dir`, for comparing
+/// against `CachedInfo::token_hash`. `token_dir` is either an account dir
+/// under `~/.claude-switch/accounts/` or `~/.claude/` for the standard
+/// fallback. Returns `None` if no token (not on macOS, not logged in, or
+/// `security` failed) — caller treats `None` as "can't verify, skip marker".
+pub fn current_token_hash(token_dir: &Path) -> Option<String> {
+    read_token(token_dir).map(|t| token_hash(&t))
 }
 
 /// Seconds elapsed since `fetched_at`. Returns `None` if the timestamp looks


### PR DESCRIPTION
## Summary

`default` is the reserved name for "the unmanaged `~/.claude/`", but until now:

- `doctor` only audited managed accounts under `~/.claude-switch/accounts/` — never `~/.claude/`
- `list` had no row for the standard config
- `status` in standard mode just printed `Active account: ~/.claude/ (standard)` with no identity info
- `claude-acc default` printed just the configured default's name, no email

So the active identity in `~/.claude/` was invisible. Even after running `doctor`, you couldn't see which Anthropic account was logged into your standard config if you'd ever logged in without the switcher. This PR closes that gap symmetrically across both distributions (Rust + shell).

## Behaviour

```
$ claude-acc list
Claude Code accounts:
  ★ work       (default)  alice@anthropic.com   3d ago
    personal              bob@anthropic.com     1h ago *
    ~/.claude/            charlie@personal.com  3d ago    (standard)

$ claude-acc status
Active account: ~/.claude/ <charlie@personal.com> (standard)

$ claude-acc default
Default: work <alice@anthropic.com>
```

The `(standard)` marker disambiguates from `(default)` — those remain two separate concepts (configured default vs unmanaged fallback). The `~/.claude/` row only appears when there's a real keychain login there or `doctor` has already cached an identity for it; empty installs don't get a phantom line.

The `*` drift convention from #20 carries through: shown on the standard row too when the current keychain token differs from the one cached at last `doctor` run.

## Implementation

- **Rust**:
  - `identity::audit_default` audits `~/.claude/`, writing to `~/.claude-switch/default.account-info.json`. Existing `audit_account` keeps its API but delegates to a shared `audit_at(token_dir, cache_path)`.
  - `identity::standard_token_dir`, `identity::default_cache_path`, `identity::read_cache_at` — small helpers exposed for `list`, `status`, `default`.
  - `Msg::ListStandard` for both en + ru ("(standard)" / "(стандартный)").
  - `commands/list.rs`: appends `~/.claude/` row when applicable, shared `cache_suffix` helper for both managed and standard.
  - `commands/status.rs`: standard mode now reads the default cache and shows `~/.claude/ <email>` inline.
  - `commands/default.rs`: no-arg path looks up the cache and appends `<email>` to the printed default name.

- **Shell** (`claude-switch.sh`):
  - `_claude_acc_default_cache_path`, `_claude_acc_default_token_dir`, `_claude_acc_default_email`, `_claude_acc_default_drift_marker`, `_claude_acc_default_suffix`.
  - `_claude_acc_write_cache` now takes a cache path directly so it can be reused for both managed and standard.
  - `list_standard` i18n key (en + ru).
  - `_claude_acc_doctor` extended with the standard-audit branch (only fires when there's a token at `~/.claude/`).
  - `_claude_acc_list`, `_claude_acc_status`, `_claude_acc_default` updated.

- **README** (en + ru): extended `doctor` section with the new row + the cache location.

## Test plan

Verified locally on macOS:
- [x] Empty default cache & no `~/.claude/` login → list/status/doctor unchanged
- [x] Faked default cache → list shows `~/.claude/` row, status standard mode shows email inline, `default` shows email
- [x] `*` drift marker appears in both managed and standard rows when cached `token_hash` differs from live
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --release` all clean
- [x] `zsh -n` / `bash -n` on all four shell scripts pass
- [x] Both Rust and shell produce identical output for the same state

`feat:` prefix → release-please will bump 0.3.0 → 0.4.0.