### PR TITLE
test: unit tests for identity, i18n, config, install (27 baseline tests)

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -174,3 +174,79 @@ fn update_eval_line(content: &str, new_eval: &str) -> String {
     result.push('\n');
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_quoted_path_eval_line() {
+        assert!(is_claude_acc_init_line(
+            r#"eval "$('/Users/me/.claude-switch/bin/claude-acc' init zsh)""#
+        ));
+    }
+
+    #[test]
+    fn detects_powershell_invocation() {
+        assert!(is_claude_acc_init_line(
+            "Invoke-Expression (& 'C:\\Users\\me\\.claude-switch\\bin\\claude-acc' init pwsh)"
+        ));
+    }
+
+    #[test]
+    fn ignores_unrelated_lines() {
+        assert!(!is_claude_acc_init_line("# Claude Code Account Switcher"));
+        assert!(!is_claude_acc_init_line("alias claudey='claude --foo'"));
+        assert!(!is_claude_acc_init_line("export PATH=/some/bin:$PATH"));
+    }
+
+    #[test]
+    fn ignores_partial_match_without_eval() {
+        // mentions claude-acc and "init" but not as an eval line
+        assert!(!is_claude_acc_init_line(
+            "# claude-acc init zsh runs on shell startup"
+        ));
+    }
+
+    #[test]
+    fn update_eval_line_replaces_single_match() {
+        let input = "\
+# unrelated
+eval \"$('/old/path/claude-acc' init zsh)\"
+# trailing
+";
+        let new_eval = "eval \"$('/new/path/claude-acc' init zsh)\"";
+        let out = update_eval_line(input, new_eval);
+        assert!(out.contains("/new/path/claude-acc"));
+        assert!(!out.contains("/old/path/claude-acc"));
+        assert!(out.contains("# unrelated"));
+        assert!(out.contains("# trailing"));
+    }
+
+    #[test]
+    fn update_eval_line_dedupes_multiple_matches_and_drops_orphan_headers() {
+        let input = "\
+# preamble
+
+# Claude Code Account Switcher
+eval \"$('/p1/claude-acc' init zsh)\"
+
+# Claude Code Account Switcher
+eval \"$('/p2/claude-acc' init zsh)\"
+
+# Claude Code Account Switcher
+eval \"$('/p3/claude-acc' init zsh)\"
+";
+        let new_eval = "eval \"$('/new/claude-acc' init zsh)\"";
+        let out = update_eval_line(input, new_eval);
+
+        // Exactly one eval line, exactly one header.
+        assert_eq!(out.matches("eval \"$(").count(), 1, "got: {out}");
+        assert_eq!(
+            out.matches("# Claude Code Account Switcher").count(),
+            1,
+            "got: {out}"
+        );
+        assert!(out.contains("/new/claude-acc"));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,3 +170,58 @@ impl AppConfig {
         fs::write(self.links_path(), content)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_name_accepts_alphanumeric() {
+        assert!(validate_name("work"));
+        assert!(validate_name("personal-2"));
+        assert!(validate_name("a_b"));
+        assert!(validate_name("WORK"));
+        assert!(validate_name("123"));
+        assert!(validate_name("a"));
+    }
+
+    #[test]
+    fn validate_name_rejects_empty() {
+        assert!(!validate_name(""));
+    }
+
+    #[test]
+    fn validate_name_rejects_path_separators_and_traversal() {
+        assert!(!validate_name("a/b"));
+        assert!(!validate_name("../etc"));
+        assert!(!validate_name(".."));
+        assert!(!validate_name("."));
+    }
+
+    #[test]
+    fn validate_name_rejects_whitespace() {
+        assert!(!validate_name("a b"));
+        assert!(!validate_name("a\tb"));
+        assert!(!validate_name(" leading"));
+    }
+
+    #[test]
+    fn validate_name_rejects_regex_metachars() {
+        assert!(!validate_name("a.b"));
+        assert!(!validate_name("a[b"));
+        assert!(!validate_name("a+b"));
+        assert!(!validate_name("a*b"));
+    }
+
+    #[test]
+    fn validate_name_rejects_links_format_break() {
+        // `=` would corrupt the path=name links file format.
+        assert!(!validate_name("a=b"));
+    }
+
+    #[test]
+    fn validate_name_rejects_unicode() {
+        assert!(!validate_name("работа"));
+        assert!(!validate_name("café"));
+    }
+}

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -314,3 +314,55 @@ fn relative_time(secs: u64, lang: Lang) -> String {
         Lang::Ru => format!("{}{} назад", n, unit_ru),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relative_time_under_minute_says_just_now() {
+        assert_eq!(relative_time(0, Lang::En), "just now");
+        assert_eq!(relative_time(59, Lang::En), "just now");
+        assert_eq!(relative_time(0, Lang::Ru), "только что");
+        assert_eq!(relative_time(59, Lang::Ru), "только что");
+    }
+
+    #[test]
+    fn relative_time_minute_boundary() {
+        assert_eq!(relative_time(60, Lang::En), "1m ago");
+        assert_eq!(relative_time(60, Lang::Ru), "1м назад");
+        assert_eq!(relative_time(3599, Lang::En), "59m ago");
+    }
+
+    #[test]
+    fn relative_time_hour_boundary() {
+        assert_eq!(relative_time(3600, Lang::En), "1h ago");
+        assert_eq!(relative_time(3600, Lang::Ru), "1ч назад");
+        assert_eq!(relative_time(86399, Lang::En), "23h ago");
+    }
+
+    #[test]
+    fn relative_time_day_boundary() {
+        assert_eq!(relative_time(86_400, Lang::En), "1d ago");
+        assert_eq!(relative_time(86_400, Lang::Ru), "1д назад");
+        assert_eq!(relative_time(604_799, Lang::En), "6d ago");
+    }
+
+    #[test]
+    fn relative_time_week_boundary() {
+        assert_eq!(relative_time(604_800, Lang::En), "1w ago");
+        assert_eq!(relative_time(604_800, Lang::Ru), "1н назад");
+    }
+
+    #[test]
+    fn relative_time_month_boundary() {
+        assert_eq!(relative_time(2_592_000, Lang::En), "1mo ago");
+        assert_eq!(relative_time(2_592_000, Lang::Ru), "1мес назад");
+    }
+
+    #[test]
+    fn relative_time_year_boundary() {
+        assert_eq!(relative_time(31_536_000, Lang::En), "1y ago");
+        assert_eq!(relative_time(31_536_000, Lang::Ru), "1г назад");
+    }
+}

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -249,3 +249,61 @@ fn fetch_profile(token: &str) -> Option<Profile> {
             .map(|s| s.to_string()),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_hash_is_deterministic() {
+        let a = token_hash("the-quick-brown-fox");
+        let b = token_hash("the-quick-brown-fox");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn token_hash_diverges_on_different_input() {
+        assert_ne!(token_hash("foo"), token_hash("bar"));
+    }
+
+    #[test]
+    fn token_hash_is_16_hex_chars() {
+        let h = token_hash("anything");
+        assert_eq!(h.len(), 16, "got {h:?}");
+        assert!(
+            h.chars().all(|c| c.is_ascii_hexdigit()),
+            "non-hex char in {h:?}"
+        );
+    }
+
+    #[test]
+    fn seconds_since_rejects_zero() {
+        assert_eq!(seconds_since(0), None);
+    }
+
+    #[test]
+    fn seconds_since_rejects_future_timestamp() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert_eq!(seconds_since(now + 86_400), None);
+    }
+
+    #[test]
+    fn seconds_since_returns_diff_for_past_timestamp() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // 100 seconds ago — give the diff a 5-second slack for slow runners.
+        let diff = seconds_since(now - 100).expect("expected Some");
+        assert!((95..=105).contains(&diff), "got diff {diff}");
+    }
+
+    #[test]
+    fn read_cache_at_missing_returns_none() {
+        let p = std::path::PathBuf::from("/definitely/does/not/exist/.account-info.json");
+        assert!(read_cache_at(&p).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Up to now `cargo test` was an empty pass — zero unit tests. Adding 27 baseline tests across the modules where a regression would actually hurt. No behaviour change; all tests are inline `#[cfg(test)]` modules with no dev-deps.

## Coverage

- **`identity`** (7 tests): `token_hash` determinism, divergence on different input, 16-hex-char output. `seconds_since` edge cases (zero timestamp, future timestamp, past timestamp returning correct diff). `read_cache_at` on a missing path.

- **`i18n::relative_time`** (7 tests): every unit boundary verified in both English and Russian — `<60s` says "just now" / "только что", and the transitions at 60s / 3600s / 86400s / 604800s / 2592000s / 31536000s produce correct unit + suffix.

- **`config::validate_name`** (7 tests): alphanumerics + `_` / `-` accepted, empty rejected, path separators / traversal rejected, whitespace / tabs rejected, regex metacharacters rejected, `=` (links-format-break) rejected, unicode rejected.

- **`commands::install`** (6 tests): `is_claude_acc_init_line` correctly identifies the POSIX `eval` form with quoted paths AND the PowerShell `Invoke-Expression` form, but ignores comments and partial mentions. `update_eval_line` replaces a single match and dedupes multiple matches, dropping orphan header comments — covers the regression fixed in #9 (the BSD-sed quirk that produced duplicate eval lines).

## Why these specific tests

I picked tests where:
1. **Behaviour is deterministic and pure** — no need for fixtures, sandbox, or mocks. (Skipped HTTP / keychain / filesystem-dependent code paths.)
2. **A regression would silently break user experience** — wrong relative-time formatting, name-validation false-positive/negative, install duplicating shell integration.

## Test plan

- [x] `cargo test --release` — 27 passed, 0 failed
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] CI on this PR will run all of the above on macOS / Linux / Windows

`test:` prefix → hidden in changelog, no release impact.