### PR TITLE
feat: `claude-acc whoami` and `doctor --json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ claude-acc link work
 | `claude-acc links` | Show all directory links |
 | `claude-acc status` | Show active account |
 | `claude-acc run <name>` | Run claude under a specific account |
-| `claude-acc doctor` | Audit each account's actual OAuth identity |
+| `claude-acc whoami` | Print the email (or name) of the active account |
+| `claude-acc doctor [--json]` | Audit each account's actual OAuth identity |
 | `claude-acc install` | Install binary and shell integration |
 
 ## How it works
@@ -214,6 +215,19 @@ Default: work <alice@anthropic.com>
 ```
 
 `doctor` audits the standard `~/.claude/` config too (the unmanaged identity used when no link / configured default applies). Its cache lives at `~/.claude-switch/default.account-info.json`. The `~/.claude/` row appears in `list` only after you've actually logged into Claude Code with the standard config (or after `doctor` has cached an identity for it).
+
+For scripting, `claude-acc doctor --json` emits the same audit information as a single JSON document — and `claude-acc whoami` prints just the email (or account name fallback) of the active account, suitable for shell prompts:
+
+```bash
+# Use in a prompt:
+PS1='[$(claude-acc whoami)] \$ '
+
+# Or in a script:
+case "$(claude-acc whoami)" in
+    alice@anthropic.com) echo "work" ;;
+    *)                   echo "other" ;;
+esac
+```
 
 The `*` after an email means the OAuth token has rotated since the cache was written. Most often this is a routine OAuth refresh (identity unchanged) — but if you ran `claude auth login` directly between `doctor` runs, this is your reminder to re-verify. Run `claude-acc doctor` to refresh the cache.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -74,7 +74,8 @@ claude-acc link work
 | `claude-acc links` | Показать все привязки директорий |
 | `claude-acc status` | Показать активный аккаунт |
 | `claude-acc run <имя>` | Запустить claude под конкретным аккаунтом |
-| `claude-acc doctor` | Аудит реальной OAuth-личности каждого аккаунта |
+| `claude-acc whoami` | Email (или имя) активного аккаунта |
+| `claude-acc doctor [--json]` | Аудит реальной OAuth-личности каждого аккаунта |
 | `claude-acc install` | Установить бинарник и shell-интеграцию |
 
 ## Как это работает
@@ -213,6 +214,19 @@ $ claude-acc default
 ```
 
 `doctor` аудитит и стандартный `~/.claude/` (неуправляемая личность, к которой claude обращается когда нет ни link'а, ни настроенного default'а). Его кэш лежит в `~/.claude-switch/default.account-info.json`. Строка `~/.claude/` появляется в `list` только если вы реально залогинены в Claude Code со стандартным config-dir (или если `doctor` уже закэшировал identity для него).
+
+Для скриптов `claude-acc doctor --json` отдаёт те же данные одним JSON-документом — а `claude-acc whoami` печатает email (или имя аккаунта как fallback) активного аккаунта, удобно для shell-prompt:
+
+```bash
+# В prompt:
+PS1='[$(claude-acc whoami)] \$ '
+
+# В скрипте:
+case "$(claude-acc whoami)" in
+    alice@anthropic.com) echo "work" ;;
+    *)                   echo "other" ;;
+esac
+```
 
 `*` после email означает что OAuth-токен изменился с момента записи кэша. Чаще всего это рутинный refresh токена (identity та же) — но если вы запускали `claude auth login` напрямую между запусками `doctor`, это напоминание что стоит перепроверить. Запустите `claude-acc doctor`, чтобы обновить кэш.
 

--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -59,6 +59,7 @@ _claude_msg_en=(
     help_status         "Current account and context"
     help_run            "Run claude under a specific account"
     help_doctor         "Audit each account OAuth identity (email, UUID)"
+    help_whoami         "Print active account email (or name fallback)"
     help_help           "Help"
     list_empty          "No accounts. Add one: claude-acc add <name>"
     list_header         "Claude Code accounts:"
@@ -126,6 +127,7 @@ _claude_msg_ru=(
     help_status         "Текущий аккаунт и контекст"
     help_run            "Запустить claude под конкретным аккаунтом"
     help_doctor         "Аудит OAuth-личности каждого аккаунта (email, UUID)"
+    help_whoami         "Email активного аккаунта (или имя как fallback)"
     help_help           "Справка"
     list_empty          "Нет аккаунтов. Добавьте: claude-acc add <name>"
     list_header         "Аккаунты Claude Code:"
@@ -408,7 +410,8 @@ _claude_acc_help() {
     echo "  claude-acc links             $(_msg help_links)"
     echo "  claude-acc status            $(_msg help_status)"
     echo "  claude-acc run <name> [...]  $(_msg help_run)"
-    echo "  claude-acc doctor            $(_msg help_doctor)"
+    echo "  claude-acc doctor [--json]   $(_msg help_doctor)"
+    echo "  claude-acc whoami            $(_msg help_whoami)"
 }
 
 _claude_acc_list() {
@@ -888,6 +891,12 @@ _claude_acc_identity_suffix() {
 }
 
 _claude_acc_doctor() {
+    local json=0
+    if [[ "$1" == "--json" ]]; then
+        json=1
+        shift
+    fi
+
     local dep
     for dep in security curl jq shasum; do
         if ! command -v "$dep" >/dev/null 2>&1; then
@@ -902,6 +911,11 @@ _claude_acc_doctor() {
     standard_dir=$(_claude_acc_default_token_dir)
     local standard_present=0
     [[ -n "$(_claude_acc_token "$standard_dir")" ]] && standard_present=1
+
+    if (( json )); then
+        _claude_acc_doctor_json "${accounts[@]}" "$standard_present"
+        return $?
+    fi
 
     if (( ${#accounts} == 0 && standard_present == 0 )); then
         _msg list_empty
@@ -973,6 +987,106 @@ _claude_acc_doctor() {
     fi
 }
 
+# JSON form of `doctor`. Last positional arg is the standard_present flag (0/1);
+# preceding args are managed-account names. Schema matches the Rust binary —
+# see src/commands/doctor.rs.
+_claude_acc_doctor_json() {
+    local args=("$@")
+    local n=${#args[@]}
+    local standard_present="${args[$n]}"
+    local accounts=("${(@)args[1,$((n-1))]}")
+    local default_acc
+    default_acc=$(_claude_default_account)
+    local any_problem=0
+
+    local entries="[]"
+    local acc acc_dir token identity audit_status email uuid org rest is_default entry
+    for acc in "${accounts[@]}"; do
+        acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$acc"
+        token=$(_claude_acc_token "$acc_dir")
+        if [[ -z "$token" ]]; then
+            audit_status="no_token"; email=""; uuid=""
+        else
+            identity=$(_claude_acc_identity "$token")
+            if [[ -z "$identity" ]]; then
+                audit_status="offline"; email=""; uuid=""
+                any_problem=1
+            else
+                audit_status="ok"
+                email="${identity%%	*}"
+                rest="${identity#*	}"
+                uuid="${rest%%	*}"
+                org="${rest#*	}"
+                [[ "$org" == "$rest" ]] && org=""
+                _claude_acc_write_cache "$(_claude_acc_cache_path "$acc_dir")" \
+                    "$email" "$uuid" "$org" "$token"
+            fi
+        fi
+        is_default=false
+        [[ "$acc" == "$default_acc" ]] && is_default=true
+        entry=$(jq -n \
+            --arg name "$acc" --arg status "$audit_status" \
+            --arg email "$email" --arg uuid "$uuid" \
+            --argjson is_default "$is_default" \
+            '{name:$name, status:$status,
+              email:(if $email == "" then null else $email end),
+              uuid:(if $uuid == "" then null else $uuid end),
+              default:$is_default}')
+        entries=$(jq --argjson e "$entry" '. + [$e]' <<< "$entries")
+    done
+
+    local standard="null"
+    if (( standard_present )); then
+        token=$(_claude_acc_token "$standard_dir" 2>/dev/null) || \
+            token=$(_claude_acc_token "$(_claude_acc_default_token_dir)")
+        identity=$(_claude_acc_identity "$token")
+        if [[ -z "$identity" ]]; then
+            audit_status="offline"; email=""; uuid=""
+            any_problem=1
+        else
+            audit_status="ok"
+            email="${identity%%	*}"
+            rest="${identity#*	}"
+            uuid="${rest%%	*}"
+            org="${rest#*	}"
+            [[ "$org" == "$rest" ]] && org=""
+            _claude_acc_write_cache "$(_claude_acc_default_cache_path)" \
+                "$email" "$uuid" "$org" "$token"
+        fi
+        standard=$(jq -n \
+            --arg name "~/.claude/" --arg status "$audit_status" \
+            --arg email "$email" --arg uuid "$uuid" \
+            '{name:$name, status:$status,
+              email:(if $email == "" then null else $email end),
+              uuid:(if $uuid == "" then null else $uuid end)}')
+    fi
+
+    jq -n --argjson accounts "$entries" --argjson standard "$standard" \
+        '{accounts:$accounts, standard:$standard}'
+    return $any_problem
+}
+
+# `whoami` — emit the most-identifying string for the active account.
+# Order: cached email > account name > literal "default" for standard.
+_claude_acc_whoami() {
+    local linked_dir account email
+    linked_dir=$(_claude_find_linked_dir)
+    if [[ -n "$linked_dir" ]]; then
+        account=$(_claude_dir_account "$linked_dir")
+    fi
+    [[ -z "$account" ]] && account=$(_claude_default_account)
+
+    if [[ -n "$account" && "$account" != "default" ]]; then
+        email=$(_claude_acc_cache_email "$account")
+        echo "${email:-$account}"
+        return 0
+    fi
+
+    # Standard ~/.claude/.
+    email=$(_claude_acc_default_email)
+    echo "${email:-default}"
+}
+
 # =============================================================
 # Единая точка входа
 # =============================================================
@@ -993,7 +1107,8 @@ claude-acc() {
         links)   _claude_acc_links ;;
         status)  _claude_acc_status "$@" ;;
         run)     _claude_acc_run "$@" ;;
-        doctor)  _claude_acc_doctor ;;
+        doctor)  _claude_acc_doctor "$@" ;;
+        whoami)  _claude_acc_whoami ;;
         help)    _claude_acc_help ;;
         *)       _claude_acc_help ;;
     esac
@@ -1018,6 +1133,7 @@ _claude_acc_completion() {
         "status:$(_msg help_status)"
         "run:$(_msg help_run)"
         "doctor:$(_msg help_doctor)"
+        "whoami:$(_msg help_whoami)"
         "help:$(_msg help_help)"
     )
 

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -29,7 +29,7 @@ _claude_acc_complete() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     if [[ $COMP_CWORD -eq 1 ]]; then
-        COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status run doctor help" -- "$cur"))
+        COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status run doctor whoami help" -- "$cur"))
     elif [[ $COMP_CWORD -eq 2 ]]; then
         case "$prev" in
             login|remove|run)

--- a/shell/init.ps1
+++ b/shell/init.ps1
@@ -27,7 +27,7 @@ Register-ArgumentCompleter -CommandName claude-acc -ScriptBlock {
     $count = $words.Count
 
     if ($count -le 2) {
-        $cmds = @('list','add','login','remove','default','reset','link','unlink','links','status','run','doctor','help')
+        $cmds = @('list','add','login','remove','default','reset','link','unlink','links','status','run','doctor','whoami','help')
         $cmds | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -38,6 +38,7 @@ _claude_acc_completion() {
         'status:Current account info'
         'run:Run claude under a specific account'
         'doctor:Audit each account OAuth identity'
+        'whoami:Print active account email'
     )
     if (( CURRENT == 2 )); then
         _describe 'command' subcmds

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -2,7 +2,7 @@ use crate::config::AppConfig;
 use crate::i18n::{I18n, Msg};
 use crate::identity::{self, AuditResult};
 
-pub fn run(config: &AppConfig, i18n: &I18n) -> i32 {
+pub fn run(config: &AppConfig, i18n: &I18n, json: bool) -> i32 {
     let accounts = match config.list_accounts() {
         Ok(v) => v,
         Err(_) => return 1,
@@ -11,10 +11,18 @@ pub fn run(config: &AppConfig, i18n: &I18n) -> i32 {
     // The standard "default" line shows up if a login exists in ~/.claude/.
     // Otherwise it would just print noise on every doctor run, so we hide it
     // when there's no token there.
-    let standard_label = "~/.claude/";
     let standard_present = identity::standard_token_dir()
         .map(|d| identity::current_token_hash(&d).is_some())
         .unwrap_or(false);
+
+    if json {
+        return run_json(config, &accounts, standard_present);
+    }
+    run_human(config, i18n, &accounts, standard_present)
+}
+
+fn run_human(config: &AppConfig, i18n: &I18n, accounts: &[String], standard_present: bool) -> i32 {
+    let standard_label = "~/.claude/";
 
     if accounts.is_empty() && !standard_present {
         i18n.print(Msg::ListEmpty);
@@ -36,7 +44,7 @@ pub fn run(config: &AppConfig, i18n: &I18n) -> i32 {
         .unwrap_or(0);
     let mut healthy = 0usize;
 
-    for acc in &accounts {
+    for acc in accounts {
         let acc_dir = config.account_path(acc);
         let pad = " ".repeat(label_w.saturating_sub(acc.len()));
         match identity::audit_account(&acc_dir) {
@@ -99,4 +107,79 @@ pub fn run(config: &AppConfig, i18n: &I18n) -> i32 {
         i18n.print(Msg::DoctorPartial(healthy, total));
         1
     }
+}
+
+/// Emit the same audit information as `run_human`, but as a single JSON
+/// document on stdout — for scripting. Schema:
+///
+/// ```json
+/// {
+///   "accounts": [
+///     {"name": "work", "status": "ok", "email": "...", "uuid": "...", "default": true},
+///     {"name": "personal", "status": "no_token", "email": null, "uuid": null, "default": false}
+///   ],
+///   "standard": {"status": "ok", "email": "...", "uuid": "..."} | null
+/// }
+/// ```
+///
+/// Same exit semantics as the human form: 0 if all audited entries are `ok`,
+/// 1 otherwise. `no_token` entries are *not* counted as failures (an account
+/// that hasn't been logged into is a known-empty state, not an error).
+fn run_json(config: &AppConfig, accounts: &[String], standard_present: bool) -> i32 {
+    let default_acc = config.get_default().ok().flatten();
+    let mut entries = Vec::with_capacity(accounts.len());
+    let mut any_problem = false;
+
+    for acc in accounts {
+        let acc_dir = config.account_path(acc);
+        let entry = build_entry(
+            acc.as_str(),
+            identity::audit_account(&acc_dir),
+            Some(default_acc.as_deref() == Some(acc.as_str())),
+        );
+        if entry["status"] == "offline" {
+            any_problem = true;
+        }
+        entries.push(entry);
+    }
+
+    let standard = if standard_present {
+        let entry = build_entry(
+            "~/.claude/",
+            identity::audit_default(&config.base_dir),
+            None,
+        );
+        if entry["status"] == "offline" {
+            any_problem = true;
+        }
+        Some(entry)
+    } else {
+        None
+    };
+
+    let doc = serde_json::json!({
+        "accounts": entries,
+        "standard": standard,
+    });
+    println!("{}", serde_json::to_string_pretty(&doc).unwrap_or_default());
+
+    if any_problem { 1 } else { 0 }
+}
+
+fn build_entry(name: &str, result: AuditResult, is_default: Option<bool>) -> serde_json::Value {
+    let (status, email, uuid) = match result {
+        AuditResult::Ok(p) => ("ok", p.email, p.uuid),
+        AuditResult::NoToken => ("no_token", None, None),
+        AuditResult::Offline => ("offline", None, None),
+    };
+    let mut obj = serde_json::json!({
+        "name": name,
+        "status": status,
+        "email": email,
+        "uuid": uuid,
+    });
+    if let Some(d) = is_default {
+        obj["default"] = serde_json::Value::Bool(d);
+    }
+    obj
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,3 +14,4 @@ pub mod reset;
 pub mod run;
 pub mod status;
 pub mod unlink;
+pub mod whoami;

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -1,0 +1,52 @@
+// `claude-acc whoami` — print the most-identifying string for the active
+// account, suitable for use in shell prompts and conditional scripts.
+//
+// Resolution order (matches `status` for active-account detection):
+//   1. Cached email (managed account or standard ~/.claude/)
+//   2. Account name (managed but no cached email)
+//   3. The literal `default` (standard with no cached identity)
+//
+// Always exits 0; output is always non-empty so scripts can compare safely.
+
+use crate::config::AppConfig;
+use crate::identity;
+use crate::resolve;
+
+pub fn run(config: &AppConfig) {
+    let cwd = std::env::current_dir().expect("Cannot get current directory");
+
+    // 1. Linked directory wins.
+    if let Some(ld) = resolve::find_linked_dir(config, &cwd)
+        && let Ok(Some(acc)) = config.get_link(&ld)
+    {
+        if acc == "default" {
+            println!("{}", standard_label(config));
+        } else {
+            println!("{}", account_label(config, &acc));
+        }
+        return;
+    }
+
+    // 2. Configured default.
+    if let Ok(Some(acc)) = config.get_default() {
+        println!("{}", account_label(config, &acc));
+        return;
+    }
+
+    // 3. Standard ~/.claude/.
+    println!("{}", standard_label(config));
+}
+
+fn account_label(config: &AppConfig, acc: &str) -> String {
+    let acc_dir = config.account_path(acc);
+    identity::read_cache(&acc_dir)
+        .and_then(|c| c.email)
+        .unwrap_or_else(|| acc.to_string())
+}
+
+fn standard_label(config: &AppConfig) -> String {
+    let cache_path = identity::default_cache_path(&config.base_dir);
+    identity::read_cache_at(&cache_path)
+        .and_then(|c| c.email)
+        .unwrap_or_else(|| "default".to_string())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,13 @@ enum Commands {
         args: Vec<String>,
     },
     /// Audit each account's actual OAuth identity (email, UUID)
-    Doctor,
+    Doctor {
+        /// Output as JSON (suitable for scripting)
+        #[arg(long)]
+        json: bool,
+    },
+    /// Print the email or account name of the active account
+    Whoami,
     /// Install binary and shell integration
     Install,
     /// Output shell activation code (used by shell hook)
@@ -94,7 +100,10 @@ fn main() {
         Some(Commands::Links) => commands::links::run(&config, &i18n),
         Some(Commands::Status) => commands::status::run(&config, &i18n),
         Some(Commands::Run { name, args }) => commands::run::run(&config, &i18n, &name, &args),
-        Some(Commands::Doctor) => std::process::exit(commands::doctor::run(&config, &i18n)),
+        Some(Commands::Doctor { json }) => {
+            std::process::exit(commands::doctor::run(&config, &i18n, json))
+        }
+        Some(Commands::Whoami) => commands::whoami::run(&config),
         Some(Commands::Install) => commands::install::run(&config, &i18n),
         Some(Commands::Activate { shell }) => {
             let syntax = match shell.as_str() {


### PR DESCRIPTION
## Summary

Two small QoL commands aimed at shell scripting and prompt integration. Follow-up to the doctor / cache work in #14, #20, #22.

### `claude-acc whoami`

Prints the most-identifying string for the active account, suitable for shell prompts and comparisons:

```bash
# As a shell prompt:
PS1='[$(claude-acc whoami)] \$ '

# In a script:
case "$(claude-acc whoami)" in
    alice@anthropic.com) echo "work" ;;
    *)                   echo "other" ;;
esac
```

Resolution order: **cached email → account name → literal `default`** (for standard `~/.claude/` with no cached identity). Always exits 0; output is always non-empty so `[[ "$(claude-acc whoami)" == ... ]]` comparisons are safe.

### `claude-acc doctor --json`

Emits the same audit information as the human form, but as a single JSON document on stdout:

```json
{
  "accounts": [
    {"name": "work", "status": "ok", "email": "alice@anthropic.com", "uuid": "aa6c22d5-...", "default": true},
    {"name": "personal", "status": "no_token", "email": null, "uuid": null, "default": false}
  ],
  "standard": {"name": "~/.claude/", "status": "ok", "email": "...", "uuid": "..."}
}
```

`status` is one of: `ok` / `no_token` / `offline`. `standard` is `null` when no live login exists in `~/.claude/`.

Same exit semantics as the human form: 0 if all audited entries are `ok`, 1 otherwise. `no_token` is not counted as failure (an account never logged into is a known-empty state, not an error).

## Implementation

- **Rust**: new `src/commands/whoami.rs`. Doctor's `Commands` variant gains a `--json` flag; `doctor.rs` splits into `run_human` and `run_json` with a shared `build_entry` helper. No new dependencies — `serde_json` was already pulled in for cache parsing.
- **Shell** (`claude-switch.sh`): `_claude_acc_whoami` mirrors the Rust resolution order. `_claude_acc_doctor` parses `--json` and dispatches to `_claude_acc_doctor_json` for JSON output (built via `jq`). One zsh quirk: had to rename a local var `status` → `audit_status` because `status` is read-only in zsh.
- Help text and zsh / bash / pwsh completions updated for both commands.
- READMEs (en + ru) extended with the new commands table entries plus usage examples.

## Test plan

Verified locally on macOS:
- [x] `whoami` in linked dir, unlinked dir with configured default, standard mode (with and without cached default identity)
- [x] `doctor --json` output validates as JSON, schema matches
- [x] Both Rust and shell produce equivalent logical output
- [x] All 27 existing tests still pass
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, all four shell scripts parse cleanly

`feat:` prefix → release-please will bump 0.4.0 → 0.5.0 on next release run.