### PR TITLE
feat: `-s, --seed` flag and `clone-settings` for seeding from ~/.claude/

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ claude-acc link work
 | --- | --- |
 | `claude-acc` | Help |
 | `claude-acc list` | List all accounts |
-| `claude-acc add <name>` | Add account (runs `claude login`) |
+| `claude-acc add <name>` | Add account (runs `claude login`); add `-s` / `--seed` to seed from `~/.claude/` |
+| `claude-acc clone-settings <name>` | Copy `settings.json` / `CLAUDE.md` / `agents/` / etc. from `~/.claude/` into an existing account |
 | `claude-acc login <name>` | Re-login to an account |
 | `claude-acc remove <name>` | Remove account |
 | `claude-acc default [name]` | Show/set default account |
@@ -156,6 +157,31 @@ No manual setup required — `claude-acc install` does both. New accounts create
 | sessions, history, etc. | Runtime data |
 
 Each account gets its own copy of all these files in `~/.claude-switch/accounts/<name>/`.
+
+## Inheriting `~/.claude/` config
+
+A fresh `claude-acc add work` produces an empty config dir — no `settings.json`, no `CLAUDE.md`, no custom agents. If you want the new account to start with the same setup as your standard `~/.claude/`, use the `-s` / `--seed` flag, or run `clone-settings` retroactively:
+
+```bash
+claude-acc add -s work               # seed at creation time
+claude-acc clone-settings work       # seed an existing account
+```
+
+Both copy a curated set of files from `~/.claude/`:
+
+**Copied** (configuration / personalization):
+- `settings.json` (env vars, permissions, hooks references, statusline, plugins, language)
+- `CLAUDE.md` (global memory)
+- `agents/`, `commands/`, `output-styles/`, `skills/` (custom assets)
+
+**Not copied** (per-account state — would defeat the isolation):
+- `.credentials.json` (auth token — re-acquired via `claude auth login`)
+- `settings.local.json` (per-machine local overrides)
+- `projects/`, `todos/`, `statsig/` (sessions, runtime state, telemetry)
+- `hooks/`, `plugins/` (settings.json references these by absolute path; copying duplicates files for nothing)
+- `.account-info.json` (the doctor cache)
+
+Existing files in the target are skipped — `clone-settings` is a one-shot seed, not a sync.
 
 ## Per-project settings
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -64,7 +64,8 @@ claude-acc link work
 | --- | --- |
 | `claude-acc` | Справка |
 | `claude-acc list` | Список всех аккаунтов |
-| `claude-acc add <имя>` | Добавить аккаунт (запустит `claude login`) |
+| `claude-acc add <имя>` | Добавить аккаунт (запустит `claude login`); добавьте `-s` / `--seed` чтобы засеять из `~/.claude/` |
+| `claude-acc clone-settings <имя>` | Скопировать `settings.json` / `CLAUDE.md` / `agents/` и т.д. из `~/.claude/` в существующий аккаунт |
 | `claude-acc login <имя>` | Перелогиниться в аккаунт |
 | `claude-acc remove <имя>` | Удалить аккаунт |
 | `claude-acc default [имя]` | Показать/задать дефолтный аккаунт |
@@ -155,6 +156,31 @@ JetBrains IDE (PhpStorm, IntelliJ и т.п.) и VSCode запускают `claud
 | sessions, history и т.д. | Runtime-данные |
 
 Каждый аккаунт получает свою копию всех этих файлов в `~/.claude-switch/accounts/<name>/`.
+
+## Наследование конфига из `~/.claude/`
+
+Свежий `claude-acc add work` создаёт **пустую** директорию — без `settings.json`, без `CLAUDE.md`, без кастомных агентов. Чтобы новый аккаунт стартовал с тем же setup'ом что и ваш стандартный `~/.claude/`, используйте флаг `-s` / `--seed` при создании или `clone-settings` ретроактивно:
+
+```bash
+claude-acc add -s work               # засеять при создании
+claude-acc clone-settings work       # засеять существующий аккаунт
+```
+
+Обе команды копируют curated set файлов из `~/.claude/`:
+
+**Копируются** (конфигурация / персонализация):
+- `settings.json` (env vars, permissions, ссылки на хуки, statusline, plugins, language)
+- `CLAUDE.md` (глобальная память)
+- `agents/`, `commands/`, `output-styles/`, `skills/` (кастомные ассеты)
+
+**Не копируются** (per-account state — иначе ломается изоляция):
+- `.credentials.json` (токен — повторно получается через `claude auth login`)
+- `settings.local.json` (per-machine локальные оверрайды)
+- `projects/`, `todos/`, `statsig/` (сессии, runtime state, телеметрия)
+- `hooks/`, `plugins/` (settings.json ссылается на них по абсолютным путям; копировать = плодить файлы без пользы)
+- `.account-info.json` (наш doctor-кэш)
+
+Существующие файлы в target'е не перезаписываются — `clone-settings` это одноразовый seed, не sync.
 
 ## Отдельные настройки для проектов
 

--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -60,6 +60,7 @@ _claude_msg_en=(
     help_run            "Run claude under a specific account"
     help_doctor         "Audit each account OAuth identity (email, UUID)"
     help_whoami         "Print active account email (or name fallback)"
+    help_clone_settings "Copy ~/.claude/ config into an existing account"
     help_help           "Help"
     list_empty          "No accounts. Add one: claude-acc add <name>"
     list_header         "Claude Code accounts:"
@@ -93,6 +94,9 @@ _claude_msg_en=(
     link_done_default   "%s → ~/.claude/ (default)"
     reserved_name       "'%s' is a reserved name."
     name_invalid        "Account name must contain only letters, digits, hyphens, and underscores."
+    seed_copied         "  copied: %s"
+    seed_nothing        "  nothing to copy from ~/.claude/"
+    clone_settings_usage "Usage: claude-acc clone-settings <name>"
     run_usage           "Usage: claude-acc run <name> [args...]"
     run_not_found       "Account '%s' not found."
     doctor_header       "Auditing %d account(s):"
@@ -128,6 +132,7 @@ _claude_msg_ru=(
     help_run            "Запустить claude под конкретным аккаунтом"
     help_doctor         "Аудит OAuth-личности каждого аккаунта (email, UUID)"
     help_whoami         "Email активного аккаунта (или имя как fallback)"
+    help_clone_settings "Скопировать конфиг ~/.claude/ в существующий аккаунт"
     help_help           "Справка"
     list_empty          "Нет аккаунтов. Добавьте: claude-acc add <name>"
     list_header         "Аккаунты Claude Code:"
@@ -161,6 +166,9 @@ _claude_msg_ru=(
     link_done_default   "%s → ~/.claude/ (default)"
     reserved_name       "'%s' — зарезервированное имя."
     name_invalid        "Имя аккаунта может содержать только буквы, цифры, дефисы и подчёркивания."
+    seed_copied         "  скопировано: %s"
+    seed_nothing        "  нечего копировать из ~/.claude/"
+    clone_settings_usage "Использование: claude-acc clone-settings <name>"
     run_usage           "Использование: claude-acc run <name> [args...]"
     run_not_found       "Аккаунт '%s' не найден."
     doctor_header       "Проверка %d аккаунт(ов):"
@@ -412,6 +420,8 @@ _claude_acc_help() {
     echo "  claude-acc run <name> [...]  $(_msg help_run)"
     echo "  claude-acc doctor [--json]   $(_msg help_doctor)"
     echo "  claude-acc whoami            $(_msg help_whoami)"
+    echo "  claude-acc add -s <name>     $(_msg help_add) (seeded from ~/.claude/)"
+    echo "  claude-acc clone-settings <name>  $(_msg help_clone_settings)"
 }
 
 _claude_acc_list() {
@@ -447,7 +457,14 @@ _claude_acc_list() {
 }
 
 _claude_acc_add() {
-    local name="$1"
+    local seed_flag=0 name=""
+    while (( $# > 0 )); do
+        case "$1" in
+            -s|--seed) seed_flag=1; shift ;;
+            *)         name="$1"; shift ;;
+        esac
+    done
+
     if [[ -z "$name" ]]; then
         _msg add_usage
         _msg add_example
@@ -470,6 +487,7 @@ _claude_acc_add() {
     mkdir -p "$acc_dir"
     mkdir -p "$HOME/.claude/ide"
     ln -sfn "$HOME/.claude/ide" "$acc_dir/ide"
+    (( seed_flag )) && _claude_acc_seed_from_default "$acc_dir"
     _msg add_created "$name"
     CLAUDE_CONFIG_DIR="$acc_dir" claude auth login
     echo ""
@@ -694,6 +712,58 @@ _claude_acc_reset() {
     sed -i '' "s/^default=.*/default=/" "$CLAUDE_SWITCH_CONFIG"
     _msg reset_done
     _claude_activate
+}
+
+# Seed an account dir with the user's standard ~/.claude/ config (curated set).
+# Skips files that already exist. Mirrors `seed::copy_user_config` in the
+# Rust binary — see src/seed.rs for the rationale on what's copied / not.
+_claude_acc_seed_from_default() {
+    local target="$1"
+    local source="$HOME/.claude"
+    [[ ! -d "$source" ]] && return 0
+
+    local files=(settings.json CLAUDE.md)
+    local dirs=(agents commands output-styles skills)
+    local any=0 f d count
+
+    for f in "${files[@]}"; do
+        if [[ -f "$source/$f" && ! -e "$target/$f" ]]; then
+            cp "$source/$f" "$target/$f"
+            _msg seed_copied "$f"
+            any=1
+        fi
+    done
+
+    for d in "${dirs[@]}"; do
+        if [[ -d "$source/$d" && ! -e "$target/$d" ]]; then
+            # Skip empty source dirs.
+            count=$(find "$source/$d" -type f 2>/dev/null | wc -l | tr -d ' ')
+            (( count == 0 )) && continue
+            cp -R "$source/$d" "$target/$d"
+            local plural=""
+            (( count != 1 )) && plural="s"
+            _msg seed_copied "$d/ ($count file$plural)"
+            any=1
+        fi
+    done
+
+    (( any == 0 )) && _msg seed_nothing
+    return 0
+}
+
+_claude_acc_clone_settings() {
+    local name="$1"
+    if [[ -z "$name" ]]; then
+        _msg clone_settings_usage
+        return 1
+    fi
+    _claude_validate_name "$name" || return 1
+    local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$name"
+    if [[ ! -d "$acc_dir" ]]; then
+        _msg login_not_found "$name"
+        return 1
+    fi
+    _claude_acc_seed_from_default "$acc_dir"
 }
 
 # Run claude under a specific account — one-shot, doesn't change links or
@@ -1110,6 +1180,7 @@ claude-acc() {
         run)     _claude_acc_run "$@" ;;
         doctor)  _claude_acc_doctor "$@" ;;
         whoami)  _claude_acc_whoami ;;
+        clone-settings) _claude_acc_clone_settings "$@" ;;
         help)    _claude_acc_help ;;
         *)       _claude_acc_help ;;
     esac
@@ -1135,6 +1206,7 @@ _claude_acc_completion() {
         "run:$(_msg help_run)"
         "doctor:$(_msg help_doctor)"
         "whoami:$(_msg help_whoami)"
+        "clone-settings:$(_msg help_clone_settings)"
         "help:$(_msg help_help)"
     )
 
@@ -1142,7 +1214,7 @@ _claude_acc_completion() {
         _describe 'command' subcmds
     elif (( CURRENT == 3 )); then
         case "${words[2]}" in
-            login|remove|run)
+            login|remove|run|clone-settings)
                 accounts=("$CLAUDE_SWITCH_ACCOUNTS_DIR"/*(N:t))
                 _describe 'account' accounts
                 ;;

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -29,10 +29,10 @@ _claude_acc_complete() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     if [[ $COMP_CWORD -eq 1 ]]; then
-        COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status run doctor whoami help" -- "$cur"))
+        COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status run doctor whoami clone-settings help" -- "$cur"))
     elif [[ $COMP_CWORD -eq 2 ]]; then
         case "$prev" in
-            login|remove|run)
+            login|remove|run|clone-settings)
                 COMPREPLY=($(compgen -W "$('__CLAUDE_ACC_BIN__' completions accounts)" -- "$cur"))
                 ;;
             default|link)

--- a/shell/init.ps1
+++ b/shell/init.ps1
@@ -27,7 +27,7 @@ Register-ArgumentCompleter -CommandName claude-acc -ScriptBlock {
     $count = $words.Count
 
     if ($count -le 2) {
-        $cmds = @('list','add','login','remove','default','reset','link','unlink','links','status','run','doctor','whoami','help')
+        $cmds = @('list','add','login','remove','default','reset','link','unlink','links','status','run','doctor','whoami','clone-settings','help')
         $cmds | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }
@@ -35,7 +35,7 @@ Register-ArgumentCompleter -CommandName claude-acc -ScriptBlock {
         $sub = $words[1]
         $accounts = @()
         switch ($sub) {
-            { $_ -in 'login','remove','run' } {
+            { $_ -in 'login','remove','run','clone-settings' } {
                 $accounts = (& '__CLAUDE_ACC_BIN__' completions accounts) -split "`n"
             }
             { $_ -in 'default','link' } {

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -39,12 +39,13 @@ _claude_acc_completion() {
         'run:Run claude under a specific account'
         'doctor:Audit each account OAuth identity'
         'whoami:Print active account email'
+        'clone-settings:Copy ~/.claude/ config into account'
     )
     if (( CURRENT == 2 )); then
         _describe 'command' subcmds
     elif (( CURRENT == 3 )); then
         case "${words[2]}" in
-            login|remove|run)
+            login|remove|run|clone-settings)
                 accounts=(${(f)"$('__CLAUDE_ACC_BIN__' completions accounts)"})
                 _describe 'account' accounts
                 ;;

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,10 +1,11 @@
 use crate::config::{AppConfig, validate_name};
 use crate::i18n::{I18n, Msg};
 use crate::ide;
+use crate::seed;
 use std::fs;
 use std::process::Command;
 
-pub fn run(config: &AppConfig, i18n: &I18n, name: &str) {
+pub fn run(config: &AppConfig, i18n: &I18n, name: &str, seed_from_default: bool) {
     if name == "default" {
         i18n.print(Msg::ReservedName(name.to_string()));
         std::process::exit(1);
@@ -23,6 +24,24 @@ pub fn run(config: &AppConfig, i18n: &I18n, name: &str) {
 
     fs::create_dir_all(&acc_dir).expect("Failed to create account directory");
     ide::ensure_account_symlink(&acc_dir).ok();
+
+    // Seed before printing AddCreated, so the copy report is logically
+    // attached to "what the new account got". Errors here are non-fatal —
+    // an empty account dir is still usable.
+    if seed_from_default {
+        match seed::copy_user_config(&acc_dir) {
+            Ok(report) if report.is_empty() => {
+                i18n.print(Msg::SeedNothingToCopy);
+            }
+            Ok(report) => {
+                for entry in &report.copied {
+                    i18n.print(Msg::SeedCopied(entry.clone()));
+                }
+            }
+            Err(e) => eprintln!("seed: {}", e),
+        }
+    }
+
     i18n.print(Msg::AddCreated(name.to_string()));
 
     Command::new("claude")

--- a/src/commands/clone_settings.rs
+++ b/src/commands/clone_settings.rs
@@ -1,0 +1,30 @@
+use crate::config::{AppConfig, validate_name};
+use crate::i18n::{I18n, Msg};
+use crate::seed;
+
+pub fn run(config: &AppConfig, i18n: &I18n, name: &str) {
+    if !validate_name(name) {
+        i18n.print(Msg::NameInvalid);
+        std::process::exit(1);
+    }
+    let acc_dir = config.account_path(name);
+    if !acc_dir.is_dir() {
+        i18n.print(Msg::LoginNotFound(name.to_string()));
+        std::process::exit(1);
+    }
+
+    match seed::copy_user_config(&acc_dir) {
+        Ok(report) if report.is_empty() => {
+            i18n.print(Msg::SeedNothingToCopy);
+        }
+        Ok(report) => {
+            for entry in &report.copied {
+                i18n.print(Msg::SeedCopied(entry.clone()));
+            }
+        }
+        Err(e) => {
+            eprintln!("clone-settings: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod activate;
 pub mod add;
+pub mod clone_settings;
 pub mod completions;
 pub mod default;
 pub mod doctor;

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -201,6 +201,12 @@ impl I18n {
                 format!("Добавьте в конфиг шелла:\n  {}", line)
             }
 
+            // seed / clone-settings
+            (Msg::SeedCopied(ref s), Lang::En) => format!("  copied: {}", s),
+            (Msg::SeedCopied(ref s), Lang::Ru) => format!("  скопировано: {}", s),
+            (Msg::SeedNothingToCopy, Lang::En) => s("  nothing to copy from ~/.claude/"),
+            (Msg::SeedNothingToCopy, Lang::Ru) => s("  нечего копировать из ~/.claude/"),
+
             // doctor
             (Msg::RelativeTime(secs), lang) => relative_time(secs, lang),
             (Msg::DoctorHeader(n), Lang::En) => format!("Auditing {} account(s):", n),
@@ -287,6 +293,8 @@ pub enum Msg {
     DoctorAllOk,
     DoctorPartial(usize, usize),
     RelativeTime(u64),
+    SeedCopied(String),
+    SeedNothingToCopy,
 }
 
 fn relative_time(secs: u64, lang: Lang) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod i18n;
 mod ide;
 mod identity;
 mod resolve;
+mod seed;
 
 use clap::{Parser, Subcommand};
 use commands::activate::ShellSyntax;
@@ -22,7 +23,17 @@ enum Commands {
     /// List all accounts
     List,
     /// Add account (runs claude login)
-    Add { name: String },
+    Add {
+        name: String,
+        /// Seed the new account dir with settings.json / CLAUDE.md / agents
+        /// / commands / output-styles / skills from your standard ~/.claude/
+        #[arg(short, long)]
+        seed: bool,
+    },
+    /// Copy curated config (settings.json, CLAUDE.md, agents/, commands/, etc.)
+    /// from ~/.claude/ into an existing account dir. Skips files that already
+    /// exist; never overwrites
+    CloneSettings { name: String },
     /// Re-login to an account
     Login { name: String },
     /// Remove account
@@ -88,7 +99,10 @@ fn main() {
             commands::list::run(&config, &i18n);
         }
         Some(Commands::List) => commands::list::run(&config, &i18n),
-        Some(Commands::Add { name }) => commands::add::run(&config, &i18n, &name),
+        Some(Commands::Add { name, seed }) => commands::add::run(&config, &i18n, &name, seed),
+        Some(Commands::CloneSettings { name }) => {
+            commands::clone_settings::run(&config, &i18n, &name)
+        }
         Some(Commands::Login { name }) => commands::login::run(&config, &i18n, &name),
         Some(Commands::Remove { force, name }) => {
             commands::remove::run(&config, &i18n, &name, force)

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,0 +1,98 @@
+// Seed a managed account dir with the user's standard `~/.claude/` config.
+//
+// What gets copied: configuration / personalization that you'd want carried
+// over to a new account dir.
+//   - settings.json (env vars, permissions, hooks references, statusline,
+//     plugins, language, defaults)
+//   - CLAUDE.md (global memory)
+//   - agents/, commands/, output-styles/, skills/ (custom user assets)
+//
+// What is NOT copied: per-account state and identity-bound things — those
+// must stay distinct between accounts or the per-account isolation breaks.
+//   - .credentials.json (auth — must be re-acquired by `claude auth login`)
+//   - settings.local.json (per-machine local overrides)
+//   - .account-info.json (our doctor cache)
+//   - projects/, todos/, statsig/ (runtime state, sessions, telemetry)
+//   - ide/ (already a symlink to ~/.claude/ide in our setup)
+//   - hooks/, plugins/ (settings.json references these by absolute path,
+//     so copying duplicates files that are never invoked from the copy)
+//
+// Existing files in the target are skipped, never overwritten — this is a
+// "seed" operation, not a sync.
+
+use std::fs;
+use std::path::Path;
+
+const COPYABLE_FILES: &[&str] = &["settings.json", "CLAUDE.md"];
+const COPYABLE_DIRS: &[&str] = &["agents", "commands", "output-styles", "skills"];
+
+pub struct CopyReport {
+    pub copied: Vec<String>,
+}
+
+impl CopyReport {
+    pub fn is_empty(&self) -> bool {
+        self.copied.is_empty()
+    }
+}
+
+pub fn copy_user_config(target: &Path) -> std::io::Result<CopyReport> {
+    let source = match dirs::home_dir() {
+        Some(h) => h.join(".claude"),
+        None => return Err(std::io::Error::other("cannot determine home directory")),
+    };
+    let mut report = CopyReport { copied: vec![] };
+
+    if !source.exists() {
+        return Ok(report);
+    }
+
+    for f in COPYABLE_FILES {
+        let src = source.join(f);
+        let dst = target.join(f);
+        if src.is_file() && !dst.exists() {
+            fs::copy(&src, &dst)?;
+            report.copied.push((*f).to_string());
+        }
+    }
+
+    for d in COPYABLE_DIRS {
+        let src = source.join(d);
+        let dst = target.join(d);
+        if !src.is_dir() || dst.exists() {
+            continue;
+        }
+        // Skip empty source dirs — copying an empty `commands/` is just noise
+        // in both the report and the destination.
+        if fs::read_dir(&src)?.next().is_none() {
+            continue;
+        }
+        let count = copy_dir_recursive(&src, &dst)?;
+        report
+            .copied
+            .push(format!("{}/ ({} file{})", d, count, plural(count)));
+    }
+
+    Ok(report)
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<usize> {
+    fs::create_dir_all(dst)?;
+    let mut count = 0;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            count += copy_dir_recursive(&path, &dst_path)?;
+        } else {
+            fs::copy(&path, &dst_path)?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}


### PR DESCRIPTION
## Summary

A fresh `claude-acc add work` used to produce an *empty* config dir — no `settings.json`, no `CLAUDE.md`, no custom agents. Users expecting "same setup but a different login" got a barren environment instead.

Adds two ways to seed a managed account dir from your standard `~/.claude/`:

```bash
claude-acc add -s work               # seed at creation time
claude-acc clone-settings work       # seed an existing account retroactively
```

`-s` / `--seed` is opt-in, so existing `add` behaviour is unchanged.

## What gets copied / skipped

Curated set, picked deliberately so per-account isolation isn't broken (full rationale in `src/seed.rs`):

| | Copied | Skipped |
|---|---|---|
| **Files** | `settings.json`, `CLAUDE.md` | `.credentials.json`, `settings.local.json`, `.account-info.json` |
| **Dirs** | `agents/`, `commands/`, `output-styles/`, `skills/` | `projects/`, `todos/`, `statsig/`, `hooks/`, `plugins/`, `ide/` |

Why those exclusions:
- `.credentials.json`: would copy auth into another account dir → defeats the entire isolation premise.
- `settings.local.json`: per-machine local overrides, not portable.
- `projects/todos/statsig/`: runtime state, sessions, telemetry — per-account by definition.
- `hooks/plugins/`: `settings.json` references these by **absolute path** (e.g. `/Users/x/.claude/hooks/foo.js`), so the original files keep working without copying. Copying just creates orphan duplicates.
- `ide/`: already a symlink to `~/.claude/ide` in our setup (#3, #4).
- `.account-info.json`: our `doctor` cache; a copy would mislead the new account about its identity.

Existing files in the target are skipped — this is a one-shot seed, not a sync. Empty source directories (e.g. user has no custom `commands/`) are also skipped to avoid plopping empty dirs into the destination.

## Implementation

- **Rust**:
  - New `src/seed.rs` with `copy_user_config(target) -> CopyReport` and recursive directory copy helper.
  - New `src/commands/clone_settings.rs` for the standalone command.
  - `Add` command gained an `#[arg(short, long)] seed: bool` — clap auto-generates both `-s` and `--seed`.

- **Shell** (`claude-switch.sh`):
  - `_claude_acc_seed_from_default` mirrors the Rust logic with `cp` (BSD-compatible).
  - `_claude_acc_clone_settings` is a thin wrapper.
  - `_claude_acc_add` parses `-s` / `--seed` before name validation.

- **i18n**: new `Msg::SeedCopied(String)` and `Msg::SeedNothingToCopy` (en + ru). Shell uses `seed_copied` / `seed_nothing` / `clone_settings_usage` / `help_clone_settings` keys.

- **Help** and **zsh/bash/pwsh completions** updated to include `clone-settings`.

- **READMEs** (en + ru) gained an "Inheriting `~/.claude/` config" section with the full copy/skip lists.

## Test plan

Verified locally on macOS:
- [x] `clone-settings` on a fresh test account dir copies `settings.json`, `CLAUDE.md`, `agents/` (33 files), `skills/` (85 files), and correctly skips empty `commands/`
- [x] `clone-settings` on an already-populated dir says "nothing to copy" — idempotent, doesn't overwrite
- [x] `clone-settings` on a missing account → "Account 'X' not found.", exit 1
- [x] `clone-settings` without name → usage hint, exit 1
- [x] `claude-acc add --help` shows `-s, --seed` correctly
- [x] Both Rust and shell produce equivalent output for the same state
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --release` (27 tests) — clean
- [x] All four shell scripts parse with `zsh -n` / `bash -n`

`feat:` prefix → release-please will bump 0.5.0 → 0.6.0 on the next release run.