### PR TITLE
fix(install): correct binary extension and shell detection on Windows

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -3,13 +3,35 @@ use crate::i18n::{I18n, Msg};
 use crate::ide;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Filename the installed binary lives under inside `~/.claude-switch/bin/`.
+/// Windows requires the `.exe` extension or the OS won't execute the file
+/// even when the path is given explicitly.
+fn binary_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "claude-acc.exe"
+    } else {
+        "claude-acc"
+    }
+}
 
 pub fn run(config: &AppConfig, i18n: &I18n) {
     let bin_dir = config.base_dir.join("bin");
     fs::create_dir_all(&bin_dir).expect("Failed to create bin directory");
 
-    let target = bin_dir.join("claude-acc");
+    let target = bin_dir.join(binary_name());
     let source = std::env::current_exe().expect("Cannot determine binary path");
+
+    // On Windows, prior versions copied the binary as `claude-acc` (no
+    // extension) which Windows can't execute. Clean that up so PATH-based
+    // lookups stop hitting the broken file.
+    if cfg!(target_os = "windows") {
+        let stale = bin_dir.join("claude-acc");
+        if stale.is_file() && stale != target {
+            let _ = fs::remove_file(&stale);
+        }
+    }
 
     // Check version
     let current_version = env!("CARGO_PKG_VERSION");
@@ -62,7 +84,7 @@ fn ensure_ide_integration(config: &AppConfig, claude_acc_bin: &Path) {
 }
 
 fn ensure_shell_integration(config: &AppConfig, i18n: &I18n) {
-    let bin_path = config.base_dir.join("bin").join("claude-acc");
+    let bin_path = config.base_dir.join("bin").join(binary_name());
     let bin_str = bin_path.to_str().expect("Invalid bin path");
 
     let (shell, rc_path) = detect_shell_and_rc();
@@ -73,6 +95,13 @@ fn ensure_shell_integration(config: &AppConfig, i18n: &I18n) {
     };
 
     if let Some(rc) = rc_path {
+        // PowerShell profile paths can point at $HOME/Documents/PowerShell/...
+        // which may not exist on a fresh install. Create parent dirs lazily.
+        if let Some(parent) = rc.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            let _ = fs::create_dir_all(parent);
+        }
         let content = fs::read_to_string(&rc).unwrap_or_default();
 
         // Match any line that mentions claude-acc + init (handles quoting
@@ -109,11 +138,16 @@ fn ensure_shell_integration(config: &AppConfig, i18n: &I18n) {
 }
 
 fn detect_shell_and_rc() -> (String, Option<PathBuf>) {
+    if cfg!(target_os = "windows") {
+        return detect_shell_windows();
+    }
+    detect_shell_unix()
+}
+
+fn detect_shell_unix() -> (String, Option<PathBuf>) {
     let home = dirs::home_dir().expect("Cannot determine home directory");
 
-    // Check SHELL env var
     let shell_env = std::env::var("SHELL").unwrap_or_default();
-
     if shell_env.contains("zsh") {
         return ("zsh".to_string(), Some(home.join(".zshrc")));
     }
@@ -122,13 +156,6 @@ fn detect_shell_and_rc() -> (String, Option<PathBuf>) {
         let profile = home.join(".bash_profile");
         let rc = if bashrc.exists() { bashrc } else { profile };
         return ("bash".to_string(), Some(rc));
-    }
-
-    // Check for PowerShell profile
-    if let Ok(profile) = std::env::var("PROFILE")
-        && !profile.is_empty()
-    {
-        return ("pwsh".to_string(), Some(PathBuf::from(profile)));
     }
 
     // Fallback: check common rc files
@@ -140,6 +167,48 @@ fn detect_shell_and_rc() -> (String, Option<PathBuf>) {
     }
 
     ("bash".to_string(), None)
+}
+
+/// Windows: PowerShell is the only target shell we support. Git Bash etc.
+/// would appear with a unix-style $SHELL but on Windows we prefer pwsh,
+/// because that's where IDEs and the standard terminal land.
+///
+/// Resolution order for the profile path:
+///   1. `pwsh -NoProfile -Command "$PROFILE"` (PowerShell 7+)
+///   2. `powershell -NoProfile -Command "$PROFILE"` (Windows PowerShell 5.x)
+///   3. Hardcoded `~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1`
+///
+/// The `$PROFILE` automatic variable in PowerShell is *not* exported to
+/// child processes by default, so we can't read it via `std::env::var`.
+fn detect_shell_windows() -> (String, Option<PathBuf>) {
+    for shell_bin in ["pwsh", "powershell"] {
+        if let Some(p) = pwsh_profile_path(shell_bin) {
+            return ("pwsh".to_string(), Some(p));
+        }
+    }
+    // Last-resort fallback: standard PSCore profile location, even if pwsh
+    // isn't on PATH. The user can always source it manually.
+    let home = dirs::home_dir().expect("Cannot determine home directory");
+    let fallback = home
+        .join("Documents")
+        .join("PowerShell")
+        .join("Microsoft.PowerShell_profile.ps1");
+    ("pwsh".to_string(), Some(fallback))
+}
+
+fn pwsh_profile_path(shell_bin: &str) -> Option<PathBuf> {
+    let out = Command::new(shell_bin)
+        .args(["-NoProfile", "-NonInteractive", "-Command", "$PROFILE"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if path.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(path))
 }
 
 fn is_claude_acc_init_line(line: &str) -> bool {
@@ -178,6 +247,18 @@ fn update_eval_line(content: &str, new_eval: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn binary_name_has_exe_on_windows() {
+        assert_eq!(binary_name(), "claude-acc.exe");
+    }
+
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn binary_name_has_no_extension_elsewhere() {
+        assert_eq!(binary_name(), "claude-acc");
+    }
 
     #[test]
     fn detects_quoted_path_eval_line() {


### PR DESCRIPTION
## Summary

`claude-acc install` was broken on Windows in two independent ways. A user just hit both at once:

```powershell
PS> & "C:\Users\s3n1a\Downloads\claude-acc.exe" install
Already up to date (v0.5.0).
Add this to your shell config:
  eval "$('C:\Users\s3n1a\.claude-switch\bin\claude-acc' init bash)"
PS> claude-acc add work
claude-acc : The term 'claude-acc' is not recognized as the name of a cmdlet, function, script file, or operable program.
```

Two bugs at once:

1. **Binary copied without `.exe`.** `~/.claude-switch/bin/claude-acc` was created instead of `claude-acc.exe`. Windows can't execute extensionless files even when the path is given explicitly, so PATH-based lookups silently fail.
2. **Shell detection fell through to bash.** On Windows `$SHELL` is unset and `$PROFILE` is a *PowerShell automatic variable*, not an exported env var — so `std::env::var("PROFILE")` returns nothing from a child process. Detection then fell into the bash branch and printed a `eval "$(...)"` line that PowerShell can't run.

## Fixes

- **`binary_name()`** returns `claude-acc.exe` on Windows, `claude-acc` elsewhere. Used by both the copy target and the eval-line path in shell integration.
- On Windows, install also removes any stale `~/.claude-switch/bin/claude-acc` (no extension) left by a previous broken install, so PATH lookups stop hitting the broken file.
- **`detect_shell_and_rc` splits into platform-specific paths.** The new `detect_shell_windows` shells out to `pwsh -NoProfile -Command "$PROFILE"` (PowerShell 7+), falls back to `powershell` (Windows PowerShell 5.x), and finally to the standard PSCore profile path under `~/Documents/PowerShell/`. Querying PowerShell directly is more reliable than guessing — non-English Windows installs put the user's Documents folder under different localized names.
- **Profile parent dir is created lazily** via `fs::create_dir_all`. A fresh Windows install where `~/Documents/PowerShell/` doesn't yet exist will no longer fail to write the profile.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --release` — 28 tests pass (27 baseline + 1 new `binary_name` test, cfg-gated per OS)
- [ ] **Cross-platform CI on this PR** will exercise the new code paths on `windows-latest`. That's the real verification — the bug was Windows-only and I'm on macOS.
- [ ] Affected user re-runs install after merge → expects `Add this to your shell config: Invoke-Expression (& '...claude-acc.exe' init pwsh)` and a working `claude-acc` on PATH.

## Workaround for users hit *before* this lands

```powershell
if (Test-Path "$HOME\.claude-switch\bin\claude-acc") {
    Rename-Item "$HOME\.claude-switch\bin\claude-acc" "$HOME\.claude-switch\bin\claude-acc.exe"
}
if (-not (Test-Path $PROFILE)) { New-Item $PROFILE -Force }
"`nInvoke-Expression (& '$HOME\.claude-switch\bin\claude-acc.exe' init pwsh)" | Add-Content $PROFILE
. $PROFILE
```

`fix:` prefix → release-please will bump 0.5.0 → 0.5.1.