### PR TITLE
fix(install): join `init pwsh` output before Invoke-Expression + Windows install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ claude-acc install
 ```
 
 This will:
-- Copy the binary to `~/.claude-switch/bin/claude-acc`
+- Copy the binary to `~/.claude-switch/bin/claude-acc` (`.exe` on Windows)
 - Install the IDE wrapper at `~/.claude-switch/bin/claude` (see [IDE integration](#ide-integration))
 - Auto-detect your shell (zsh/bash/PowerShell)
 - Add shell integration to your rc file
+- On Windows: also append `~/.claude-switch/bin` to the user `PATH`
 
 To update, download the new version and run `claude-acc install` again.
 
@@ -36,6 +37,23 @@ To update, download the new version and run `claude-acc install` again.
 cargo install --path .
 claude-acc install
 ```
+
+#### Windows
+
+PowerShell on a fresh Windows install needs two extra steps before `claude-acc` works:
+
+1. **Allow the profile to run.** The default execution policy blocks the PowerShell profile, so the shell-integration line we add to it never executes:
+   ```powershell
+   Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
+   ```
+2. **Run `install` by full path the first time.** The bin directory isn't on `PATH` yet, so type out the path of the binary you just downloaded:
+   ```powershell
+   & "$HOME\Downloads\claude-acc.exe" install
+   ```
+   This copies the binary to `~/.claude-switch/bin/claude-acc.exe`, registers the PowerShell profile entry, and adds `~/.claude-switch/bin` to your user `PATH`.
+3. **Restart PowerShell.** The new `PATH` is only picked up by newly-spawned shells. After that, plain `claude-acc add work` works from anywhere.
+
+Affected by an older broken install (binary copied without `.exe`, or shell line written for bash)? Re-run `claude-acc install` — it auto-cleans the stale extension-less binary and rewrites the profile line for PowerShell.
 
 ### Shell script (zsh-only)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ This will:
 - Install the IDE wrapper at `~/.claude-switch/bin/claude` (see [IDE integration](#ide-integration))
 - Auto-detect your shell (zsh/bash/PowerShell)
 - Add shell integration to your rc file
-- On Windows: also append `~/.claude-switch/bin` to the user `PATH`
 
 To update, download the new version and run `claude-acc install` again.
 
@@ -42,16 +41,15 @@ claude-acc install
 
 PowerShell on a fresh Windows install needs two extra steps before `claude-acc` works:
 
-1. **Allow the profile to run.** The default execution policy blocks the PowerShell profile, so the shell-integration line we add to it never executes:
+1. **Allow the profile to run.** The default execution policy blocks the PowerShell profile, so the shell-integration line we add to it never executes — and that line is what puts `~/.claude-switch/bin` on `PATH` for the session:
    ```powershell
    Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
    ```
-2. **Run `install` by full path the first time.** The bin directory isn't on `PATH` yet, so type out the path of the binary you just downloaded:
+2. **Run `install` by full path the first time.** The bin directory isn't on `PATH` yet, so call the `.exe` you just downloaded directly:
    ```powershell
    & "$HOME\Downloads\claude-acc.exe" install
    ```
-   This copies the binary to `~/.claude-switch/bin/claude-acc.exe`, registers the PowerShell profile entry, and adds `~/.claude-switch/bin` to your user `PATH`.
-3. **Restart PowerShell.** The new `PATH` is only picked up by newly-spawned shells. After that, plain `claude-acc add work` works from anywhere.
+3. **Restart PowerShell.** The profile only runs at shell startup, so the new `PATH` (and `cd`-activation) take effect in newly-spawned shells. After that, plain `claude-acc add work` works from anywhere.
 
 Affected by an older broken install (binary copied without `.exe`, or shell line written for bash)? Re-run `claude-acc install` — it auto-cleans the stale extension-less binary and rewrites the profile line for PowerShell.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -21,10 +21,11 @@ claude-acc install
 ```
 
 Это:
-- Скопирует бинарник в `~/.claude-switch/bin/claude-acc`
+- Скопирует бинарник в `~/.claude-switch/bin/claude-acc` (на Windows — `.exe`)
 - Установит IDE-wrapper в `~/.claude-switch/bin/claude` (см. [Интеграция с IDE](#интеграция-с-ide))
 - Определит ваш шелл (zsh/bash/PowerShell)
 - Добавит интеграцию в rc-файл
+- На Windows — добавит `~/.claude-switch/bin` в пользовательский `PATH`
 
 Для обновления — скачайте новую версию и снова запустите `claude-acc install`.
 
@@ -34,6 +35,23 @@ claude-acc install
 cargo install --path .
 claude-acc install
 ```
+
+#### Windows
+
+На свежей Windows-машине PowerShell нужны два дополнительных шага, иначе `claude-acc` не заработает:
+
+1. **Разрешить запуск профиля.** Дефолтная execution-policy блокирует PowerShell-профиль, так что shell-init строка, которую мы туда пишем, не выполнится:
+   ```powershell
+   Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
+   ```
+2. **Запустить `install` по полному пути.** Bin-директория ещё не в `PATH`, так что прямо указываем путь к скачанному `.exe`:
+   ```powershell
+   & "$HOME\Downloads\claude-acc.exe" install
+   ```
+   Это скопирует бинарник в `~/.claude-switch/bin/claude-acc.exe`, пропишет строку в PowerShell-профиль и добавит `~/.claude-switch/bin` в пользовательский `PATH`.
+3. **Перезапустить PowerShell.** Новый `PATH` подхватывают только новые процессы. После рестарта `claude-acc add work` работает откуда угодно.
+
+Если поймали старый сломанный install (бинарник без `.exe` или строка для bash в профиле) — просто перезапустите `claude-acc install`. Он сам почистит безрасширенный бинарник и перепишет строку профиля под PowerShell.
 
 ### Shell-скрипт (только zsh)
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -25,7 +25,6 @@ claude-acc install
 - Установит IDE-wrapper в `~/.claude-switch/bin/claude` (см. [Интеграция с IDE](#интеграция-с-ide))
 - Определит ваш шелл (zsh/bash/PowerShell)
 - Добавит интеграцию в rc-файл
-- На Windows — добавит `~/.claude-switch/bin` в пользовательский `PATH`
 
 Для обновления — скачайте новую версию и снова запустите `claude-acc install`.
 
@@ -40,16 +39,15 @@ claude-acc install
 
 На свежей Windows-машине PowerShell нужны два дополнительных шага, иначе `claude-acc` не заработает:
 
-1. **Разрешить запуск профиля.** Дефолтная execution-policy блокирует PowerShell-профиль, так что shell-init строка, которую мы туда пишем, не выполнится:
+1. **Разрешить запуск профиля.** Дефолтная execution-policy блокирует PowerShell-профиль, так что shell-init строка, которую мы туда пишем, не выполнится — а именно она кладёт `~/.claude-switch/bin` в `PATH` сессии:
    ```powershell
    Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
    ```
-2. **Запустить `install` по полному пути.** Bin-директория ещё не в `PATH`, так что прямо указываем путь к скачанному `.exe`:
+2. **Запустить `install` по полному пути.** Bin-директория ещё не в `PATH`, так что вызываем скачанный `.exe` напрямую:
    ```powershell
    & "$HOME\Downloads\claude-acc.exe" install
    ```
-   Это скопирует бинарник в `~/.claude-switch/bin/claude-acc.exe`, пропишет строку в PowerShell-профиль и добавит `~/.claude-switch/bin` в пользовательский `PATH`.
-3. **Перезапустить PowerShell.** Новый `PATH` подхватывают только новые процессы. После рестарта `claude-acc add work` работает откуда угодно.
+3. **Перезапустить PowerShell.** Профиль выполняется только при старте шелла, поэтому новый `PATH` (и `cd`-активация) подхватываются только в новых процессах. После рестарта `claude-acc add work` работает откуда угодно.
 
 Если поймали старый сломанный install (бинарник без `.exe` или строка для bash в профиле) — просто перезапустите `claude-acc install`. Он сам почистит безрасширенный бинарник и перепишет строку профиля под PowerShell.
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -97,7 +97,14 @@ fn ensure_shell_integration(config: &AppConfig, i18n: &I18n) {
     let (shell, rc_path) = detect_shell_and_rc();
 
     let eval_line = match shell.as_str() {
-        "pwsh" | "powershell" => format!("Invoke-Expression (& '{}' init pwsh)", bin_str),
+        // PowerShell collects child-process output as `string[]` (one
+        // element per line). Invoke-Expression only evaluates a scalar,
+        // so without the `-join "`n"` it silently runs only the first
+        // line of `init pwsh` (a comment) and the integration is dead.
+        "pwsh" | "powershell" => format!(
+            "Invoke-Expression ((& '{}' init pwsh) -join \"`n\")",
+            bin_str
+        ),
         _ => format!("eval \"$('{0}' init {1})\"", bin_str, shell),
     };
 
@@ -375,6 +382,12 @@ mod tests {
 
     #[test]
     fn detects_powershell_invocation() {
+        // Current shape (with -join "`n").
+        assert!(is_claude_acc_init_line(
+            "Invoke-Expression ((& 'C:\\Users\\me\\.claude-switch\\bin\\claude-acc' init pwsh) -join \"`n\")"
+        ));
+        // Pre-0.6.1 shape — must still match so re-running `install`
+        // upgrades existing users to the joined variant.
         assert!(is_claude_acc_init_line(
             "Invoke-Expression (& 'C:\\Users\\me\\.claude-switch\\bin\\claude-acc' init pwsh)"
         ));

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -74,6 +74,13 @@ pub fn run(config: &AppConfig, i18n: &I18n) {
 
     ensure_ide_integration(config, &target);
     ensure_shell_integration(config, i18n);
+
+    // Windows-only: PowerShell can't resolve `claude-acc` without the bin
+    // directory on user PATH. Unix users invoke the binary via the eval
+    // line in their rc file (full path), so they don't need this.
+    if cfg!(target_os = "windows") {
+        ensure_bin_in_user_path(&bin_dir, i18n);
+    }
 }
 
 fn ensure_ide_integration(config: &AppConfig, claude_acc_bin: &Path) {
@@ -211,6 +218,105 @@ fn pwsh_profile_path(shell_bin: &str) -> Option<PathBuf> {
     Some(PathBuf::from(path))
 }
 
+/// Ensure `bin_dir` is on the user `PATH` (Windows only).
+///
+/// On Windows, typing `claude-acc` in PowerShell requires the bin dir to be
+/// on `PATH`. We update the *user-scoped* environment variable (HKCU) via
+/// PowerShell's `[Environment]::SetEnvironmentVariable`, which also
+/// broadcasts `WM_SETTINGCHANGE` so newly spawned shells pick it up.
+///
+/// Currently running shells still need to be restarted — we surface that
+/// via `InstallPathRestartHint`.
+fn ensure_bin_in_user_path(bin_dir: &Path, i18n: &I18n) {
+    let bin_str = match bin_dir.to_str() {
+        Some(s) => s,
+        // Non-UTF8 path — extremely unlikely on Windows under HOMEDRIVE,
+        // but we'd rather skip than panic.
+        None => return,
+    };
+
+    let Some(current) = read_user_path() else {
+        // Couldn't read user PATH (no pwsh/powershell on PATH, or both
+        // failed). Fall back to telling the user how to add it manually.
+        i18n.print(Msg::InstallPathManual(bin_str.to_string()));
+        return;
+    };
+
+    if path_contains(&current, bin_str) {
+        i18n.print(Msg::InstallPathAlready(bin_str.to_string()));
+        return;
+    }
+
+    let new_path = if current.is_empty() {
+        bin_str.to_string()
+    } else if current.ends_with(';') {
+        format!("{}{}", current, bin_str)
+    } else {
+        format!("{};{}", current, bin_str)
+    };
+
+    if write_user_path(&new_path) {
+        i18n.print(Msg::InstallPathAdded(bin_str.to_string()));
+        i18n.print(Msg::InstallPathRestartHint);
+    } else {
+        i18n.print(Msg::InstallPathManual(bin_str.to_string()));
+    }
+}
+
+fn read_user_path() -> Option<String> {
+    for shell_bin in ["pwsh", "powershell"] {
+        let Ok(out) = Command::new(shell_bin)
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "[Environment]::GetEnvironmentVariable('Path', 'User')",
+            ])
+            .output()
+        else {
+            // pwsh likely not installed; try the next shell.
+            continue;
+        };
+        if out.status.success() {
+            return Some(String::from_utf8_lossy(&out.stdout).trim().to_string());
+        }
+    }
+    None
+}
+
+fn write_user_path(new_path: &str) -> bool {
+    // Pass the new value via an env var to dodge PowerShell quoting issues
+    // around paths with spaces / special chars.
+    for shell_bin in ["pwsh", "powershell"] {
+        let status = Command::new(shell_bin)
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "[Environment]::SetEnvironmentVariable('Path', $env:CLAUDE_ACC_NEW_PATH, 'User')",
+            ])
+            .env("CLAUDE_ACC_NEW_PATH", new_path)
+            .status();
+        if matches!(status, Ok(s) if s.success()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Case-insensitive, trailing-slash-tolerant membership check for `;`-split
+/// Windows PATH entries.
+fn path_contains(path: &str, target: &str) -> bool {
+    let normalize = |s: &str| s.trim().trim_end_matches(['/', '\\']).to_ascii_lowercase();
+    let target_norm = normalize(target);
+    if target_norm.is_empty() {
+        return false;
+    }
+    path.split(';')
+        .map(normalize)
+        .any(|entry| entry == target_norm)
+}
+
 fn is_claude_acc_init_line(line: &str) -> bool {
     line.contains("claude-acc")
         && line.contains("init")
@@ -302,6 +408,26 @@ eval \"$('/old/path/claude-acc' init zsh)\"
         assert!(!out.contains("/old/path/claude-acc"));
         assert!(out.contains("# unrelated"));
         assert!(out.contains("# trailing"));
+    }
+
+    #[test]
+    fn path_contains_matches_case_insensitive_and_trailing_slash() {
+        let path = r"C:\Windows\System32;C:\Users\me\.cargo\bin;C:\Users\me\.claude-switch\bin\";
+        assert!(path_contains(path, r"C:\Users\me\.claude-switch\bin"));
+        // Same dir, different case
+        assert!(path_contains(path, r"c:\users\me\.claude-switch\bin"));
+    }
+
+    #[test]
+    fn path_contains_rejects_non_member() {
+        let path = r"C:\Windows\System32;C:\Users\me\.cargo\bin";
+        assert!(!path_contains(path, r"C:\Users\me\.claude-switch\bin"));
+    }
+
+    #[test]
+    fn path_contains_handles_empty_path() {
+        assert!(!path_contains("", r"C:\Users\me\.claude-switch\bin"));
+        assert!(!path_contains(r"C:\Users\me\.claude-switch\bin", ""));
     }
 
     #[test]

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -74,13 +74,6 @@ pub fn run(config: &AppConfig, i18n: &I18n) {
 
     ensure_ide_integration(config, &target);
     ensure_shell_integration(config, i18n);
-
-    // Windows-only: PowerShell can't resolve `claude-acc` without the bin
-    // directory on user PATH. Unix users invoke the binary via the eval
-    // line in their rc file (full path), so they don't need this.
-    if cfg!(target_os = "windows") {
-        ensure_bin_in_user_path(&bin_dir, i18n);
-    }
 }
 
 fn ensure_ide_integration(config: &AppConfig, claude_acc_bin: &Path) {
@@ -225,105 +218,6 @@ fn pwsh_profile_path(shell_bin: &str) -> Option<PathBuf> {
     Some(PathBuf::from(path))
 }
 
-/// Ensure `bin_dir` is on the user `PATH` (Windows only).
-///
-/// On Windows, typing `claude-acc` in PowerShell requires the bin dir to be
-/// on `PATH`. We update the *user-scoped* environment variable (HKCU) via
-/// PowerShell's `[Environment]::SetEnvironmentVariable`, which also
-/// broadcasts `WM_SETTINGCHANGE` so newly spawned shells pick it up.
-///
-/// Currently running shells still need to be restarted — we surface that
-/// via `InstallPathRestartHint`.
-fn ensure_bin_in_user_path(bin_dir: &Path, i18n: &I18n) {
-    let bin_str = match bin_dir.to_str() {
-        Some(s) => s,
-        // Non-UTF8 path — extremely unlikely on Windows under HOMEDRIVE,
-        // but we'd rather skip than panic.
-        None => return,
-    };
-
-    let Some(current) = read_user_path() else {
-        // Couldn't read user PATH (no pwsh/powershell on PATH, or both
-        // failed). Fall back to telling the user how to add it manually.
-        i18n.print(Msg::InstallPathManual(bin_str.to_string()));
-        return;
-    };
-
-    if path_contains(&current, bin_str) {
-        i18n.print(Msg::InstallPathAlready(bin_str.to_string()));
-        return;
-    }
-
-    let new_path = if current.is_empty() {
-        bin_str.to_string()
-    } else if current.ends_with(';') {
-        format!("{}{}", current, bin_str)
-    } else {
-        format!("{};{}", current, bin_str)
-    };
-
-    if write_user_path(&new_path) {
-        i18n.print(Msg::InstallPathAdded(bin_str.to_string()));
-        i18n.print(Msg::InstallPathRestartHint);
-    } else {
-        i18n.print(Msg::InstallPathManual(bin_str.to_string()));
-    }
-}
-
-fn read_user_path() -> Option<String> {
-    for shell_bin in ["pwsh", "powershell"] {
-        let Ok(out) = Command::new(shell_bin)
-            .args([
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                "[Environment]::GetEnvironmentVariable('Path', 'User')",
-            ])
-            .output()
-        else {
-            // pwsh likely not installed; try the next shell.
-            continue;
-        };
-        if out.status.success() {
-            return Some(String::from_utf8_lossy(&out.stdout).trim().to_string());
-        }
-    }
-    None
-}
-
-fn write_user_path(new_path: &str) -> bool {
-    // Pass the new value via an env var to dodge PowerShell quoting issues
-    // around paths with spaces / special chars.
-    for shell_bin in ["pwsh", "powershell"] {
-        let status = Command::new(shell_bin)
-            .args([
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                "[Environment]::SetEnvironmentVariable('Path', $env:CLAUDE_ACC_NEW_PATH, 'User')",
-            ])
-            .env("CLAUDE_ACC_NEW_PATH", new_path)
-            .status();
-        if matches!(status, Ok(s) if s.success()) {
-            return true;
-        }
-    }
-    false
-}
-
-/// Case-insensitive, trailing-slash-tolerant membership check for `;`-split
-/// Windows PATH entries.
-fn path_contains(path: &str, target: &str) -> bool {
-    let normalize = |s: &str| s.trim().trim_end_matches(['/', '\\']).to_ascii_lowercase();
-    let target_norm = normalize(target);
-    if target_norm.is_empty() {
-        return false;
-    }
-    path.split(';')
-        .map(normalize)
-        .any(|entry| entry == target_norm)
-}
-
 fn is_claude_acc_init_line(line: &str) -> bool {
     line.contains("claude-acc")
         && line.contains("init")
@@ -421,26 +315,6 @@ eval \"$('/old/path/claude-acc' init zsh)\"
         assert!(!out.contains("/old/path/claude-acc"));
         assert!(out.contains("# unrelated"));
         assert!(out.contains("# trailing"));
-    }
-
-    #[test]
-    fn path_contains_matches_case_insensitive_and_trailing_slash() {
-        let path = r"C:\Windows\System32;C:\Users\me\.cargo\bin;C:\Users\me\.claude-switch\bin\";
-        assert!(path_contains(path, r"C:\Users\me\.claude-switch\bin"));
-        // Same dir, different case
-        assert!(path_contains(path, r"c:\users\me\.claude-switch\bin"));
-    }
-
-    #[test]
-    fn path_contains_rejects_non_member() {
-        let path = r"C:\Windows\System32;C:\Users\me\.cargo\bin";
-        assert!(!path_contains(path, r"C:\Users\me\.claude-switch\bin"));
-    }
-
-    #[test]
-    fn path_contains_handles_empty_path() {
-        assert!(!path_contains("", r"C:\Users\me\.claude-switch\bin"));
-        assert!(!path_contains(r"C:\Users\me\.claude-switch\bin", ""));
     }
 
     #[test]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -200,32 +200,6 @@ impl I18n {
             (Msg::InstallShellManual(ref line), Lang::Ru) => {
                 format!("Добавьте в конфиг шелла:\n  {}", line)
             }
-            (Msg::InstallPathAdded(ref dir), Lang::En) => {
-                format!("Added {} to user PATH.", dir)
-            }
-            (Msg::InstallPathAdded(ref dir), Lang::Ru) => {
-                format!("Добавлено {} в PATH пользователя.", dir)
-            }
-            (Msg::InstallPathAlready(ref dir), Lang::En) => {
-                format!("{} already in user PATH.", dir)
-            }
-            (Msg::InstallPathAlready(ref dir), Lang::Ru) => {
-                format!("{} уже в PATH пользователя.", dir)
-            }
-            (Msg::InstallPathManual(ref dir), Lang::En) => format!(
-                "Could not update user PATH automatically. Add manually:\n  setx PATH \"%PATH%;{}\"",
-                dir
-            ),
-            (Msg::InstallPathManual(ref dir), Lang::Ru) => format!(
-                "Не удалось обновить PATH автоматически. Добавьте вручную:\n  setx PATH \"%PATH%;{}\"",
-                dir
-            ),
-            (Msg::InstallPathRestartHint, Lang::En) => {
-                s("Restart PowerShell for the new PATH to take effect.")
-            }
-            (Msg::InstallPathRestartHint, Lang::Ru) => {
-                s("Перезапустите PowerShell, чтобы новый PATH применился.")
-            }
 
             // seed / clone-settings
             (Msg::SeedCopied(ref s), Lang::En) => format!("  copied: {}", s),
@@ -313,10 +287,6 @@ pub enum Msg {
     InstallShellUpdated(String),
     InstallShellAdded(String),
     InstallShellManual(String),
-    InstallPathAdded(String),
-    InstallPathAlready(String),
-    InstallPathManual(String),
-    InstallPathRestartHint,
     DoctorHeader(usize),
     DoctorNoToken(String),
     DoctorOffline,

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -200,6 +200,32 @@ impl I18n {
             (Msg::InstallShellManual(ref line), Lang::Ru) => {
                 format!("Добавьте в конфиг шелла:\n  {}", line)
             }
+            (Msg::InstallPathAdded(ref dir), Lang::En) => {
+                format!("Added {} to user PATH.", dir)
+            }
+            (Msg::InstallPathAdded(ref dir), Lang::Ru) => {
+                format!("Добавлено {} в PATH пользователя.", dir)
+            }
+            (Msg::InstallPathAlready(ref dir), Lang::En) => {
+                format!("{} already in user PATH.", dir)
+            }
+            (Msg::InstallPathAlready(ref dir), Lang::Ru) => {
+                format!("{} уже в PATH пользователя.", dir)
+            }
+            (Msg::InstallPathManual(ref dir), Lang::En) => format!(
+                "Could not update user PATH automatically. Add manually:\n  setx PATH \"%PATH%;{}\"",
+                dir
+            ),
+            (Msg::InstallPathManual(ref dir), Lang::Ru) => format!(
+                "Не удалось обновить PATH автоматически. Добавьте вручную:\n  setx PATH \"%PATH%;{}\"",
+                dir
+            ),
+            (Msg::InstallPathRestartHint, Lang::En) => {
+                s("Restart PowerShell for the new PATH to take effect.")
+            }
+            (Msg::InstallPathRestartHint, Lang::Ru) => {
+                s("Перезапустите PowerShell, чтобы новый PATH применился.")
+            }
 
             // seed / clone-settings
             (Msg::SeedCopied(ref s), Lang::En) => format!("  copied: {}", s),
@@ -287,6 +313,10 @@ pub enum Msg {
     InstallShellUpdated(String),
     InstallShellAdded(String),
     InstallShellManual(String),
+    InstallPathAdded(String),
+    InstallPathAlready(String),
+    InstallPathManual(String),
+    InstallPathRestartHint,
     DoctorHeader(usize),
     DoctorNoToken(String),
     DoctorOffline,


### PR DESCRIPTION
## Summary

A user reported that on a fresh Windows PowerShell session `cd`-driven account switching never engaged. Debugging it with them turned up two install-time issues that compound:

1. **The shell-init line we wrote into the profile was broken.** Since #29 we've been writing
   ```powershell
   Invoke-Expression (& 'C:\…\claude-acc.exe' init pwsh)
   ```
   PowerShell collects external-process stdout as `string[]` (one element per line). Passing that array to `Invoke-Expression` joins with spaces, fusing the function definitions and the `LocationChangedAction` hook onto one line — the script silently fails to parse the integration. User-discovered fix that this PR bakes in:
   ```powershell
   Invoke-Expression ((& 'C:\…\claude-acc.exe' init pwsh) -join \"\`n\")
   ```
2. **The default execution policy blocks the PowerShell profile entirely.** Even with a correct integration line, a fresh Windows install rejects the profile with *running scripts is disabled on this system*. The user has to allow it.

`shell/init.ps1` already takes care of prepending `~/.claude-switch/bin` to `\$env:PATH` on every profile load, so once Invoke-Expression actually evaluates the script, `claude-acc add work` resolves from any directory.

## Changes

- **`install` writes the joined Invoke-Expression line:**
  ```powershell
  Invoke-Expression ((& '…claude-acc.exe' init pwsh) -join \"\`n\")
  ```
  `is_claude_acc_init_line` keeps matching the pre-0.6.1 shape, so the dedupe path upgrades existing users when they re-run `install`.
- **README + README.ru gain a \"Windows\" section** covering the two prerequisites:
  1. \`Set-ExecutionPolicy -Scope CurrentUser RemoteSigned\` so the profile is allowed to run at all.
  2. Bootstrapping the first \`install\` by full path (\`& \"\$HOME\\Downloads\\claude-acc.exe\" install\`) since the bin dir isn't on \`PATH\` yet.
  3. Restarting PowerShell so the profile-driven \`PATH\` prepend (and \`cd\` activation) apply.

Net code change is one Rust line + one updated test + the README sections. (The branch initially also wrote `~/.claude-switch/bin` into HKCU via `setx`-style PowerShell calls, but that was redundant — `init.ps1` already handles \`PATH\` per-session — and got reverted in 6b54ab3.)

## Test plan

- [x] \`cargo fmt --check\`, \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test --release\` — 28 pass (baseline; the now-reverted \`path_contains\` tests went out with the revert)
- [ ] **Windows CI on this PR.** macOS can't exercise the Invoke-Expression path; the test only verifies the line shape via \`is_claude_acc_init_line\`.
- [ ] Affected user re-runs \`& \"…\\claude-acc.exe\" install\` after merge. Expectation: profile line is rewritten to the joined form; after restarting PowerShell, \`cd\` switches accounts and \`claude-acc <subcmd>\` resolves from anywhere.

\`fix:\` prefix → release-please will bump 0.6.0 → 0.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)