### PR TITLE
docs: document Windows TUI workaround for first-time account login

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ PowerShell on a fresh Windows install needs two extra steps before `claude-acc` 
 
 Affected by an older broken install (binary copied without `.exe`, or shell line written for bash)? Re-run `claude-acc install` — it auto-cleans the stale extension-less binary and rewrites the profile line for PowerShell.
 
+**Logging in on Windows.** `claude-acc add <name>` and `claude-acc login <name>` both spawn `claude auth login` under the new `CLAUDE_CONFIG_DIR`. On Windows that subcommand falls back to plain-text mode (no TUI), and the OAuth localhost callback frequently races ahead — so the `Paste code here if prompted >` prompt is unreliable for entering the code by hand. Workaround: after `claude-acc add <name>` has created the account directory, drive the login through Claude Code's first-launch TUI instead:
+
+```powershell
+claude-acc run <name>
+```
+
+This invokes `claude` directly under the account's `CLAUDE_CONFIG_DIR`, which triggers Claude Code's standard welcome → `Select login method:` flow. The in-TUI login accepts your code reliably and writes credentials to `~/.claude-switch/accounts/<name>/`. Verify with `claude-acc doctor` — each account should show its own email and UUID.
+
 ### Shell script (zsh-only)
 
 ```bash

--- a/README.ru.md
+++ b/README.ru.md
@@ -51,6 +51,14 @@ claude-acc install
 
 Если поймали старый сломанный install (бинарник без `.exe` или строка для bash в профиле) — просто перезапустите `claude-acc install`. Он сам почистит безрасширенный бинарник и перепишет строку профиля под PowerShell.
 
+**Логин на Windows.** `claude-acc add <имя>` и `claude-acc login <имя>` оба спавнят `claude auth login` под новый `CLAUDE_CONFIG_DIR`. На Windows эта подкоманда сваливается в plain-text режим (без TUI), а OAuth-callback localhost обычно отрабатывает быстрее, чем пользователь успевает вставить код вручную — приглашение `Paste code here if prompted >` ненадёжно. Обход: после того как `claude-acc add <имя>` создал директорию аккаунта, пройти логин через стандартный first-launch TUI самого Claude Code:
+
+```powershell
+claude-acc run <имя>
+```
+
+Это запустит `claude` напрямую под `CLAUDE_CONFIG_DIR` аккаунта и откроет стандартный welcome → `Select login method:`. Логин в TUI принимает код корректно и пишет credentials в `~/.claude-switch/accounts/<имя>/`. Проверить можно через `claude-acc doctor` — у каждого аккаунта должен быть свой email и UUID.
+
 ### Shell-скрипт (только zsh)
 
 ```bash


### PR DESCRIPTION
## Summary

Affected Windows users hit two compounding issues when running `claude-acc add <name>` or `claude-acc login <name>`:

1. **Plain-text auth fallback.** `claude auth login` (which we spawn under the account's `CLAUDE_CONFIG_DIR`) drops to a non-TUI flow on Windows when the config dir is fresh. The user gets `Paste code here if prompted >` instead of the standard welcome screen.
2. **OAuth localhost callback races the prompt.** The user reported `Login successful.` printed on the *same line* as the prompt with no input registered — the localhost redirect fired before they could paste anything. Visible in the original screenshots.

Net effect: manually pasting an OAuth code on Windows is unreliable.

## Workaround we verified

Skip `claude auth login` entirely and drive login through Claude Code's normal first-launch TUI:

```powershell
claude-acc run <name>
```

This invokes `claude` directly (no subcommand) under the account's `CLAUDE_CONFIG_DIR`, which triggers the standard welcome → `Select login method: …` flow. The in-TUI login accepts the code reliably and writes credentials into `~/.claude-switch/accounts/<name>/`.

Confirmed by the user's `claude-acc doctor` after using this path: `work` resolves to a different identity (email + UUID) from `~/.claude/`, proving real isolation rather than the previous shared-credential outcome.

## Changes

- README.md: new \"Logging in on Windows\" paragraph at the end of the Windows install section.
- README.ru.md: same content in Russian.

No code changes. The fix is in Claude Code's domain (plain-text auth flow + localhost-callback race on Windows); we just document the workaround that already works today.

## Test plan

- [x] Verified workaround end-to-end via screenshots from a Windows tester (`claude-acc run work` → TUI → `Select login method` → successful login → `doctor` shows distinct identity per account).
- [x] No code touched.

\`docs:\` prefix → release-please bumps patch (\`0.6.1 → 0.6.2\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)