### PR TITLE
docs: keep clone-settings help short so commands list stays aligned

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,10 @@ enum Commands {
         #[arg(short, long)]
         seed: bool,
     },
-    /// Copy curated config (settings.json, CLAUDE.md, agents/, commands/, etc.)
-    /// from ~/.claude/ into an existing account dir. Skips files that already
-    /// exist; never overwrites
+    /// Seed an existing account dir from ~/.claude/
+    ///
+    /// Copies settings.json, CLAUDE.md, agents/, commands/, output-styles/,
+    /// and skills/. Skips files that already exist; never overwrites.
     CloneSettings { name: String },
     /// Re-login to an account
     Login { name: String },


### PR DESCRIPTION
## Summary

The doc-comment on `CloneSettings` in `src/main.rs` was a single ~190-character paragraph spread across three `///` lines. Clap derives the short \"about\" by joining all `///` lines with no blank separator, so the entire text becomes one description shown in the top-level commands list.

On a typical terminal width that line overflows the description column. Clap then wraps to a continuation line without re-indenting to the column start — visible in the user's screenshot, where every command below `clone-settings` looks misaligned because the wrap eats one row at column 1:

> ![before](https://user-images.githubusercontent.com/.../clone-settings-broken-column.png)
> ```
>   clone-settings  Copy curated config (settings.json, CLAUDE.md, agents/, commands/, etc.) from ~/.claude/
>    into an existing account dir. Skips files that already exist; never overwrites
>   login           Re-login to an account
> ```

## Fix

Split the doc-comment into clap's idiomatic short / long form:

```rust
/// Seed an existing account dir from ~/.claude/
///
/// Copies settings.json, CLAUDE.md, agents/, commands/, output-styles/,
/// and skills/. Skips files that already exist; never overwrites.
CloneSettings { name: String },
```

Result:

```
$ claude-acc --help
…
  clone-settings  Seed an existing account dir from ~/.claude/
…

$ claude-acc help clone-settings
Seed an existing account dir from ~/.claude/

Copies settings.json, CLAUDE.md, agents/, commands/, output-styles/, and skills/. Skips files that already exist; never overwrites.

Usage: claude-acc clone-settings <NAME>
…
```

The detail (\"copies these, skips those\") moves to the long-form help, which is exactly what `--help` on a specific subcommand is for.

## Test plan

- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --release` — 28 pass
- [x] Visually verified `claude-acc --help` and `claude-acc help clone-settings` output (shown above)

`docs:` prefix → release-please bumps patch (`0.6.2 → 0.6.3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)