### PR TITLE
feat: show subscription plan/tier in doctor, list, and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ No manual setup required — `claude-acc install` does both. New accounts create
 
 Each account gets its own copy of all these files in `~/.claude-switch/accounts/<name>/`.
 
+### Per-account default model
+
+Because every account has its own `settings.json`, you get a per-account default model for free — no extra flag or config. Set Claude Code's [`model`](https://code.claude.com/docs/en/settings) key in that account's settings file:
+
+```bash
+# e.g. Opus on work, a lighter model on personal
+echo '{ "model": "opus" }' > ~/.claude-switch/accounts/work/settings.json
+```
+
+Now any `claude` started under the `work` account boots with that model. (Tools that symlink a single shared `settings.json` across accounts can't do this without a separate mechanism — here it's just the isolated config dir doing its job.)
+
 ## Inheriting `~/.claude/` config
 
 A fresh `claude-acc add work` produces an empty config dir — no `settings.json`, no `CLAUDE.md`, no custom agents. If you want the new account to start with the same setup as your standard `~/.claude/`, use the `-s` / `--seed` flag, or run `clone-settings` retroactively:
@@ -236,27 +247,29 @@ claude-acc link work-ml
 
 `claude-acc add` and `claude-acc login` both run `claude auth login` under a per-account `CLAUDE_CONFIG_DIR`. Whatever Anthropic account you sign in with becomes the identity for that directory — and there's no built-in surface to see which account is actually behind a given config dir. If you accidentally log in with the wrong identity (browser auto-fill, a stale tab), the switch is silent: rate limits, conversation history, and billing leak across what you thought were isolated accounts.
 
-`claude-acc doctor` reads each account's OAuth token from the macOS Keychain (with a `.credentials.json` fallback for non-Keychain installs), calls `https://api.anthropic.com/api/oauth/profile`, and prints the live email + UUID:
+`claude-acc doctor` reads each account's OAuth token from the macOS Keychain (with a `.credentials.json` fallback for non-Keychain installs), calls `https://api.anthropic.com/api/oauth/profile`, and prints the live email, plan, and UUID:
 
 ```
 $ claude-acc doctor
 Auditing 2 account(s):
-  ✓ work      alice@anthropic.com  uuid=aa6c22d5-…
+  ✓ work      alice@anthropic.com  Max 20x  uuid=aa6c22d5-…
   ? personal  no token (run: claude-acc login personal)
 
 1 of 2 accounts healthy.
 ```
 
+The plan label (`Max 20x` / `Max` / `Pro`) is derived from the profile's tier flags and `rate_limit_tier`; it's omitted for accounts with no recognizable subscription.
+
 It's purely a read-only audit — nothing is intercepted, no `claude` invocation is gated. Run it whenever you want to confirm a config dir is bound to the identity you expect. Requires `security`, `curl`, `jq`, and `shasum` (all preinstalled on macOS); the Rust binary uses native `serde_json` and `sha2` instead and only shells out to `security` and `curl`.
 
-`doctor` also caches the result to `~/.claude-switch/accounts/<name>/.account-info.json` so `list`, `status`, and `default` can show the email next to each account without re-hitting the API:
+`doctor` also caches the result (email, plan, UUID) to `~/.claude-switch/accounts/<name>/.account-info.json` so `list`, `usage`, `status`, and `default` can show the identity next to each account without re-hitting the API:
 
 ```
 $ claude-acc list
 Claude Code accounts:
-  ★ work       (default)  alice@anthropic.com   3d ago
-    personal              bob@anthropic.com     1h ago *
-    ~/.claude/            charlie@personal.com  3d ago    (standard)
+  ★ work       (default)  alice@anthropic.com   Max 20x  3d ago
+    personal              bob@anthropic.com     Pro      1h ago *
+    ~/.claude/            charlie@personal.com  Max 5x   3d ago    (standard)
 
 $ claude-acc status
 Active account: work <alice@anthropic.com> (linked to my-project)
@@ -291,15 +304,15 @@ The `*` after an email means the OAuth token has rotated since the cache was wri
 ```
 $ claude-acc usage
 Claude Code usage:
-  ★ work  alice@anthropic.com
+  ★ work  <alice@anthropic.com>  Max 20x
       5h  [████████░░░░░░░░░░░░]   42%  resets in 2h 14m
       7d  [██░░░░░░░░░░░░░░░░░░]   11%  resets in 5d 17h
-    personal  bob@anthropic.com
+    personal  <bob@anthropic.com>  Pro
       5h  [░░░░░░░░░░░░░░░░░░░░]    0%  available now
       7d  [░░░░░░░░░░░░░░░░░░░░]    0%  resets in 6d 3h
 ```
 
-Unlike `doctor`, this is always a live fetch — usage is volatile, so nothing is cached. Accounts with no token show `no token (run: claude-acc login <name>)`; an unreachable API shows `token present, but API unreachable`. Same dependencies and platform caveat as `doctor` (`security`, `curl`, `jq`, `shasum`; macOS only for now).
+Unlike `doctor`, the usage figures are always a live fetch — usage is volatile, so nothing is cached. The email/plan next to each account come from `doctor`'s cache, so run `claude-acc doctor` once to populate them. Accounts with no token show `no token (run: claude-acc login <name>)`; an unreachable API shows `token present, but API unreachable`. Same dependencies and platform caveat as `doctor` (`security`, `curl`, `jq`, `shasum`; macOS only for now).
 
 ## Language
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -182,6 +182,17 @@ JetBrains IDE (PhpStorm, IntelliJ и т.п.) и VSCode запускают `claud
 
 Каждый аккаунт получает свою копию всех этих файлов в `~/.claude-switch/accounts/<name>/`.
 
+### Дефолтная модель на аккаунт
+
+Поскольку у каждого аккаунта свой `settings.json`, дефолтная модель на аккаунт работает «из коробки» — без отдельного флага или конфига. Пропишите ключ [`model`](https://code.claude.com/docs/en/settings) Claude Code в settings.json нужного аккаунта:
+
+```bash
+# например, Opus на work и модель полегче на personal
+echo '{ "model": "opus" }' > ~/.claude-switch/accounts/work/settings.json
+```
+
+Теперь любой `claude`, запущенный под аккаунтом `work`, стартует с этой моделью. (Тулзы, которые шарят один `settings.json` через симлинк между аккаунтами, так не умеют без отдельного механизма — здесь это просто следствие изолированного config-dir.)
+
 ## Наследование конфига из `~/.claude/`
 
 Свежий `claude-acc add work` создаёт **пустую** директорию — без `settings.json`, без `CLAUDE.md`, без кастомных агентов. Чтобы новый аккаунт стартовал с тем же setup'ом что и ваш стандартный `~/.claude/`, используйте флаг `-s` / `--seed` при создании или `clone-settings` ретроактивно:
@@ -235,27 +246,29 @@ claude-acc link work-ml
 
 `claude-acc add` и `claude-acc login` оба запускают `claude auth login` под персональным `CLAUDE_CONFIG_DIR`. С каким Anthropic-аккаунтом вы залогинились — тот и привязан к этой директории. Встроенного способа увидеть, *какой именно* аккаунт реально стоит за config dir, нет. Если случайно залогинились не той учёткой (browser auto-fill, забытая вкладка), переключение происходит молча: лимиты, история диалогов и биллинг перепутаются между «изолированными» аккаунтами без всяких признаков.
 
-`claude-acc doctor` читает OAuth-токен каждого аккаунта из macOS Keychain (с fallback на `.credentials.json` для установок без Keychain), дёргает `https://api.anthropic.com/api/oauth/profile` и печатает реальный email + UUID:
+`claude-acc doctor` читает OAuth-токен каждого аккаунта из macOS Keychain (с fallback на `.credentials.json` для установок без Keychain), дёргает `https://api.anthropic.com/api/oauth/profile` и печатает реальные email, план и UUID:
 
 ```
 $ claude-acc doctor
 Проверка 2 аккаунт(ов):
-  ✓ work      alice@anthropic.com  uuid=aa6c22d5-…
+  ✓ work      alice@anthropic.com  Max 20x  uuid=aa6c22d5-…
   ? personal  нет токена (запустите: claude-acc login personal)
 
 1 из 2 аккаунтов в порядке.
 ```
 
+Метка плана (`Max 20x` / `Max` / `Pro`) выводится из tier-флагов профиля и `rate_limit_tier`; для аккаунтов без распознаваемой подписки она опускается.
+
 Это исключительно read-only аудит — ничего не перехватывается, запуск `claude` не блокируется. Запускайте когда хочется убедиться, что за config dir стоит ожидаемая личность. Требует `security`, `curl`, `jq`, `shasum` (всё предустановлено на macOS); Rust-бинарник использует нативные `serde_json` и `sha2`, шеллаутит только `security` и `curl`.
 
-`doctor` ещё кэширует результат в `~/.claude-switch/accounts/<name>/.account-info.json`, чтобы `list`, `status` и `default` показывали email рядом с каждым аккаунтом без повторных API-запросов:
+`doctor` ещё кэширует результат (email, план, UUID) в `~/.claude-switch/accounts/<name>/.account-info.json`, чтобы `list`, `usage`, `status` и `default` показывали личность рядом с каждым аккаунтом без повторных API-запросов:
 
 ```
 $ claude-acc list
 Аккаунты Claude Code:
-  ★ work       (по умолчанию)  alice@anthropic.com   3д назад
-    personal                   bob@anthropic.com     1ч назад *
-    ~/.claude/                 charlie@personal.com  3д назад    (стандартный)
+  ★ work       (по умолчанию)  alice@anthropic.com   Max 20x  3д назад
+    personal                   bob@anthropic.com     Pro      1ч назад *
+    ~/.claude/                 charlie@personal.com  Max 5x   3д назад    (стандартный)
 
 $ claude-acc status
 Активный аккаунт: work <alice@anthropic.com> (привязан к my-project)
@@ -290,15 +303,15 @@ esac
 ```
 $ claude-acc usage
 Использование Claude Code:
-  ★ work  alice@anthropic.com
+  ★ work  <alice@anthropic.com>  Max 20x
       5h  [████████░░░░░░░░░░░░]   42%  сброс через 2ч 14м
       7d  [██░░░░░░░░░░░░░░░░░░]   11%  сброс через 5д 17ч
-    personal  bob@anthropic.com
+    personal  <bob@anthropic.com>  Pro
       5h  [░░░░░░░░░░░░░░░░░░░░]    0%  доступно сейчас
       7d  [░░░░░░░░░░░░░░░░░░░░]    0%  сброс через 6д 3ч
 ```
 
-В отличие от `doctor`, это всегда живой запрос — данные использования изменчивы, поэтому ничего не кэшируется. Аккаунты без токена показывают `нет токена (запустите: claude-acc login <имя>)`; недоступный API — `токен есть, API недоступен`. Зависимости и ограничение платформы те же, что у `doctor` (`security`, `curl`, `jq`, `shasum`; пока только macOS).
+В отличие от `doctor`, сами цифры использования всегда тянутся вживую — данные изменчивы, поэтому не кэшируются. Email/план рядом с аккаунтом берутся из кэша `doctor`, так что один раз запустите `claude-acc doctor`, чтобы их заполнить. Аккаунты без токена показывают `нет токена (запустите: claude-acc login <имя>)`; недоступный API — `токен есть, API недоступен`. Зависимости и ограничение платформы те же, что у `doctor` (`security`, `curl`, `jq`, `shasum`; пока только macOS).
 
 ## Язык
 

--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -822,7 +822,10 @@ _claude_acc_token() {
     jq -r '.claudeAiOauth.accessToken // empty' "$acc_dir/.credentials.json" 2>/dev/null
 }
 
-# Echoes "<email>\t<uuid>\t<org>" or empty on failure.
+# Echoes "<email>\t<uuid>\t<org>\t<plan>" or empty on failure. `plan` is a
+# friendly tier label ("Max 20x" / "Pro" / "") derived from the boolean flags
+# plus the multiplier in organization.rate_limit_tier — mirrors derive_plan()
+# in the Rust src/identity.rs.
 _claude_acc_identity() {
     local token="$1"
     [[ -z "$token" ]] && return 1
@@ -830,7 +833,15 @@ _claude_acc_identity() {
         -H "Authorization: Bearer $token" \
         -H "anthropic-beta: oauth-2025-04-20" \
         https://api.anthropic.com/api/oauth/profile 2>/dev/null \
-        | jq -r '"\(.account.email // "<unknown>")\t\(.account.uuid // "<unknown>")\t\(.organization.name // "")"' 2>/dev/null
+        | jq -r '
+            (.account.has_claude_max // false) as $max
+            | (.account.has_claude_pro // false) as $pro
+            | (.organization.rate_limit_tier // "") as $tier
+            | (($tier | [scan("[0-9]+x")][0]) // "") as $mult
+            | (if $max then ("Max" + (if $mult != "" then " " + $mult else "" end))
+               elif $pro then "Pro" else "" end) as $plan
+            | "\(.account.email // "<unknown>")\t\(.account.uuid // "<unknown>")\t\(.organization.name // "")\t\($plan)"
+          ' 2>/dev/null
 }
 
 # sha256(token)[0:16] — used as cache invalidation signal.
@@ -855,7 +866,7 @@ _claude_acc_default_token_dir() {
 }
 
 _claude_acc_write_cache() {
-    local cache="$1" email="$2" uuid="$3" org="$4" token="$5"
+    local cache="$1" email="$2" uuid="$3" org="$4" token="$5" plan="$6"
     local now hash
     now=$(date +%s)
     hash=$(_claude_acc_token_hash "$token")
@@ -865,8 +876,14 @@ _claude_acc_write_cache() {
         --arg org "$org" \
         --argjson fetched_at "$now" \
         --arg token_hash "$hash" \
-        '{email:$email, uuid:$uuid, org:$org, fetched_at:$fetched_at, token_hash:$token_hash}' \
+        --arg plan "$plan" \
+        '{email:$email, uuid:$uuid, org:$org, fetched_at:$fetched_at, token_hash:$token_hash, plan:$plan}' \
         > "$cache" 2>/dev/null
+}
+
+_claude_acc_cache_plan() {
+    local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$1"
+    jq -r '.plan // empty' "$(_claude_acc_cache_path "$acc_dir")" 2>/dev/null
 }
 
 _claude_acc_cache_email() {
@@ -921,6 +938,10 @@ _claude_acc_default_email() {
     jq -r '.email // empty' "$(_claude_acc_default_cache_path)" 2>/dev/null
 }
 
+_claude_acc_default_plan() {
+    jq -r '.plan // empty' "$(_claude_acc_default_cache_path)" 2>/dev/null
+}
+
 _claude_acc_default_drift_marker() {
     local cached current
     cached=$(jq -r '.token_hash // empty' "$(_claude_acc_default_cache_path)" 2>/dev/null)
@@ -931,9 +952,9 @@ _claude_acc_default_drift_marker() {
 }
 
 # Suffix for the unmanaged ~/.claude/ row in `list`. Empty if no cache or
-# no email; otherwise "  email  3d ago" with optional ` *` drift marker.
+# no email; otherwise "  email  Max 20x  3d ago" with optional ` *` drift marker.
 _claude_acc_default_suffix() {
-    local cache email fetched now secs when drift
+    local cache email fetched now secs when drift plan plan_seg
     cache=$(_claude_acc_default_cache_path)
     [[ ! -f "$cache" ]] && return 0
     email=$(jq -r '.email // empty' "$cache" 2>/dev/null)
@@ -947,28 +968,34 @@ _claude_acc_default_suffix() {
             when=$(_claude_acc_relative_time "$secs")
         fi
     fi
+    plan=$(_claude_acc_default_plan)
+    plan_seg=""
+    [[ -n "$plan" ]] && plan_seg="  $plan"
     drift=$(_claude_acc_default_drift_marker)
     if [[ -n "$when" ]]; then
-        printf '  %s  %s%s' "$email" "$when" "$drift"
+        printf '  %s%s  %s%s' "$email" "$plan_seg" "$when" "$drift"
     else
-        printf '  %s%s' "$email" "$drift"
+        printf '  %s%s%s' "$email" "$plan_seg" "$drift"
     fi
 }
 
-# Rendered "  email  3d ago" / "  email  3d ago *" / "" suffix for list/status.
+# Rendered "  email  Max 20x  3d ago" / "… *" / "" suffix for list/status.
 _claude_acc_identity_suffix() {
-    local name="$1" email when secs drift
+    local name="$1" email when secs drift plan plan_seg
     email=$(_claude_acc_cache_email "$name")
     [[ -z "$email" ]] && return 0
     secs=$(_claude_acc_cache_age "$name")
     if [[ -n "$secs" ]]; then
         when=$(_claude_acc_relative_time "$secs")
     fi
+    plan=$(_claude_acc_cache_plan "$name")
+    plan_seg=""
+    [[ -n "$plan" ]] && plan_seg="  $plan"
     drift=$(_claude_acc_cache_drift_marker "$name")
     if [[ -n "$when" ]]; then
-        printf '  %s  %s%s' "$email" "$when" "$drift"
+        printf '  %s%s  %s%s' "$email" "$plan_seg" "$when" "$drift"
     else
-        printf '  %s%s' "$email" "$drift"
+        printf '  %s%s%s' "$email" "$plan_seg" "$drift"
     fi
 }
 
@@ -1092,13 +1119,15 @@ _claude_acc_usage() {
 
     _msg usage_header
 
-    local acc marker email
+    local acc marker email plan plan_seg
     for acc in "${accounts[@]}"; do
         marker=" "
         [[ "$acc" == "$default_acc" ]] && marker="★"
         email=$(_claude_acc_cache_email "$acc")
+        plan=$(_claude_acc_cache_plan "$acc")
+        plan_seg=""; [[ -n "$plan" ]] && plan_seg="  $plan"
         if [[ -n "$email" ]]; then
-            printf "  %s %s  <%s>\n" "$marker" "$acc" "$email"
+            printf "  %s %s  <%s>%s\n" "$marker" "$acc" "$email" "$plan_seg"
         else
             printf "  %s %s\n" "$marker" "$acc"
         fi
@@ -1107,8 +1136,10 @@ _claude_acc_usage() {
 
     if (( standard_present )); then
         email=$(_claude_acc_default_email)
+        plan=$(_claude_acc_default_plan)
+        plan_seg=""; [[ -n "$plan" ]] && plan_seg="  $plan"
         if [[ -n "$email" ]]; then
-            printf "    ~/.claude/  <%s>  %s\n" "$email" "$(_msg list_standard)"
+            printf "    ~/.claude/  <%s>%s  %s\n" "$email" "$plan_seg" "$(_msg list_standard)"
         else
             printf "    ~/.claude/  %s\n" "$(_msg list_standard)"
         fi
@@ -1160,7 +1191,7 @@ _claude_acc_doctor() {
         (( ${#standard_label} > width )) && width=${#standard_label}
     fi
 
-    local healthy=0 token identity email uuid org rest cache_path
+    local healthy=0 token identity email uuid org plan plan_seg cache_path
     for acc in "${accounts[@]}"; do
         local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$acc"
         token=$(_claude_acc_token "$acc_dir")
@@ -1173,14 +1204,11 @@ _claude_acc_doctor() {
             printf "  ? %-${width}s  %s\n" "$acc" "$(_msg doctor_offline)"
             continue
         fi
-        email="${identity%%	*}"
-        rest="${identity#*	}"
-        uuid="${rest%%	*}"
-        org="${rest#*	}"
-        [[ "$org" == "$rest" ]] && org=""
+        IFS=$'\t' read -r email uuid org plan <<< "$identity"
         cache_path=$(_claude_acc_cache_path "$acc_dir")
-        _claude_acc_write_cache "$cache_path" "$email" "$uuid" "$org" "$token"
-        printf "  ✓ %-${width}s  %s  uuid=%s\n" "$acc" "$email" "$uuid"
+        _claude_acc_write_cache "$cache_path" "$email" "$uuid" "$org" "$token" "$plan"
+        plan_seg=""; [[ -n "$plan" ]] && plan_seg="  $plan"
+        printf "  ✓ %-${width}s  %s%s  uuid=%s\n" "$acc" "$email" "$plan_seg" "$uuid"
         (( healthy++ ))
     done
 
@@ -1190,15 +1218,12 @@ _claude_acc_doctor() {
         if [[ -z "$identity" ]]; then
             printf "  ? %-${width}s  %s\n" "$standard_label" "$(_msg doctor_offline)"
         else
-            email="${identity%%	*}"
-            rest="${identity#*	}"
-            uuid="${rest%%	*}"
-            org="${rest#*	}"
-            [[ "$org" == "$rest" ]] && org=""
+            IFS=$'\t' read -r email uuid org plan <<< "$identity"
             cache_path=$(_claude_acc_default_cache_path)
-            _claude_acc_write_cache "$cache_path" "$email" "$uuid" "$org" "$token"
-            printf "  ✓ %-${width}s  %s  uuid=%s  (%s)\n" \
-                "$standard_label" "$email" "$uuid" "$(_msg list_standard)"
+            _claude_acc_write_cache "$cache_path" "$email" "$uuid" "$org" "$token" "$plan"
+            plan_seg=""; [[ -n "$plan" ]] && plan_seg="  $plan"
+            printf "  ✓ %-${width}s  %s%s  uuid=%s  (%s)\n" \
+                "$standard_label" "$email" "$plan_seg" "$uuid" "$(_msg list_standard)"
             (( healthy++ ))
         fi
     fi
@@ -1226,37 +1251,34 @@ _claude_acc_doctor_json() {
     local any_problem=0
 
     local entries="[]"
-    local acc acc_dir token identity audit_status email uuid org rest is_default entry
+    local acc acc_dir token identity audit_status email uuid org plan is_default entry
     for acc in "${accounts[@]}"; do
         acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$acc"
         token=$(_claude_acc_token "$acc_dir")
         if [[ -z "$token" ]]; then
-            audit_status="no_token"; email=""; uuid=""
+            audit_status="no_token"; email=""; uuid=""; plan=""
         else
             identity=$(_claude_acc_identity "$token")
             if [[ -z "$identity" ]]; then
-                audit_status="offline"; email=""; uuid=""
+                audit_status="offline"; email=""; uuid=""; plan=""
                 any_problem=1
             else
                 audit_status="ok"
-                email="${identity%%	*}"
-                rest="${identity#*	}"
-                uuid="${rest%%	*}"
-                org="${rest#*	}"
-                [[ "$org" == "$rest" ]] && org=""
+                IFS=$'\t' read -r email uuid org plan <<< "$identity"
                 _claude_acc_write_cache "$(_claude_acc_cache_path "$acc_dir")" \
-                    "$email" "$uuid" "$org" "$token"
+                    "$email" "$uuid" "$org" "$token" "$plan"
             fi
         fi
         is_default=false
         [[ "$acc" == "$default_acc" ]] && is_default=true
         entry=$(jq -n \
             --arg name "$acc" --arg status "$audit_status" \
-            --arg email "$email" --arg uuid "$uuid" \
+            --arg email "$email" --arg uuid "$uuid" --arg plan "$plan" \
             --argjson is_default "$is_default" \
             '{name:$name, status:$status,
               email:(if $email == "" then null else $email end),
               uuid:(if $uuid == "" then null else $uuid end),
+              plan:(if $plan == "" then null else $plan end),
               default:$is_default}')
         entries=$(jq --argjson e "$entry" '. + [$e]' <<< "$entries")
     done
@@ -1267,24 +1289,21 @@ _claude_acc_doctor_json() {
             token=$(_claude_acc_token "$(_claude_acc_default_token_dir)")
         identity=$(_claude_acc_identity "$token")
         if [[ -z "$identity" ]]; then
-            audit_status="offline"; email=""; uuid=""
+            audit_status="offline"; email=""; uuid=""; plan=""
             any_problem=1
         else
             audit_status="ok"
-            email="${identity%%	*}"
-            rest="${identity#*	}"
-            uuid="${rest%%	*}"
-            org="${rest#*	}"
-            [[ "$org" == "$rest" ]] && org=""
+            IFS=$'\t' read -r email uuid org plan <<< "$identity"
             _claude_acc_write_cache "$(_claude_acc_default_cache_path)" \
-                "$email" "$uuid" "$org" "$token"
+                "$email" "$uuid" "$org" "$token" "$plan"
         fi
         standard=$(jq -n \
             --arg name "~/.claude/" --arg status "$audit_status" \
-            --arg email "$email" --arg uuid "$uuid" \
+            --arg email "$email" --arg uuid "$uuid" --arg plan "$plan" \
             '{name:$name, status:$status,
               email:(if $email == "" then null else $email end),
-              uuid:(if $uuid == "" then null else $uuid end)}')
+              uuid:(if $uuid == "" then null else $uuid end),
+              plan:(if $plan == "" then null else $plan end)}')
     fi
 
     jq -n --argjson accounts "$entries" --argjson standard "$standard" \

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,6 +1,15 @@
 use crate::config::AppConfig;
 use crate::i18n::{I18n, Msg};
-use crate::identity::{self, AuditResult};
+use crate::identity::{self, AuditResult, Profile};
+
+/// "  Max 20x" when the profile carries a plan, else "". Rendered right after
+/// the email in the human audit output.
+fn plan_seg(p: &Profile) -> String {
+    p.plan
+        .as_deref()
+        .map(|s| format!("  {}", s))
+        .unwrap_or_default()
+}
 
 pub fn run(config: &AppConfig, i18n: &I18n, json: bool) -> i32 {
     let accounts = match config.list_accounts() {
@@ -52,7 +61,14 @@ fn run_human(config: &AppConfig, i18n: &I18n, accounts: &[String], standard_pres
                 healthy += 1;
                 let email = p.email.as_deref().unwrap_or("<unknown>");
                 let uuid = p.uuid.as_deref().unwrap_or("<unknown>");
-                println!("  ✓ {}{}  {}  uuid={}", acc, pad, email, uuid);
+                println!(
+                    "  ✓ {}{}  {}{}  uuid={}",
+                    acc,
+                    pad,
+                    email,
+                    plan_seg(&p),
+                    uuid
+                );
             }
             AuditResult::NoToken => {
                 println!(
@@ -76,10 +92,11 @@ fn run_human(config: &AppConfig, i18n: &I18n, accounts: &[String], standard_pres
                 let email = p.email.as_deref().unwrap_or("<unknown>");
                 let uuid = p.uuid.as_deref().unwrap_or("<unknown>");
                 println!(
-                    "  ✓ {}{}  {}  uuid={}  ({})",
+                    "  ✓ {}{}  {}{}  uuid={}  ({})",
                     standard_label,
                     pad,
                     email,
+                    plan_seg(&p),
                     uuid,
                     i18n.msg(Msg::ListStandard)
                 );
@@ -115,10 +132,10 @@ fn run_human(config: &AppConfig, i18n: &I18n, accounts: &[String], standard_pres
 /// ```json
 /// {
 ///   "accounts": [
-///     {"name": "work", "status": "ok", "email": "...", "uuid": "...", "default": true},
-///     {"name": "personal", "status": "no_token", "email": null, "uuid": null, "default": false}
+///     {"name": "work", "status": "ok", "email": "...", "uuid": "...", "plan": "Max 20x", "default": true},
+///     {"name": "personal", "status": "no_token", "email": null, "uuid": null, "plan": null, "default": false}
 ///   ],
-///   "standard": {"status": "ok", "email": "...", "uuid": "..."} | null
+///   "standard": {"status": "ok", "email": "...", "uuid": "...", "plan": "..."} | null
 /// }
 /// ```
 ///
@@ -167,16 +184,17 @@ fn run_json(config: &AppConfig, accounts: &[String], standard_present: bool) -> 
 }
 
 fn build_entry(name: &str, result: AuditResult, is_default: Option<bool>) -> serde_json::Value {
-    let (status, email, uuid) = match result {
-        AuditResult::Ok(p) => ("ok", p.email, p.uuid),
-        AuditResult::NoToken => ("no_token", None, None),
-        AuditResult::Offline => ("offline", None, None),
+    let (status, email, uuid, plan) = match result {
+        AuditResult::Ok(p) => ("ok", p.email, p.uuid, p.plan),
+        AuditResult::NoToken => ("no_token", None, None, None),
+        AuditResult::Offline => ("offline", None, None, None),
     };
     let mut obj = serde_json::json!({
         "name": name,
         "status": status,
         "email": email,
         "uuid": uuid,
+        "plan": plan,
     });
     if let Some(d) = is_default {
         obj["default"] = serde_json::Value::Bool(d);

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -86,10 +86,16 @@ fn cache_suffix(
         _ => "",
     };
 
+    let plan = cache
+        .plan
+        .as_deref()
+        .map(|p| format!("  {}", p))
+        .unwrap_or_default();
+
     let body = if when.is_empty() {
-        format!("  {}{}", email, drift)
+        format!("  {}{}{}", email, plan, drift)
     } else {
-        format!("  {}  {}{}", email, when, drift)
+        format!("  {}{}  {}{}", email, plan, when, drift)
     };
     format!("{}{}", body, skip_label)
 }

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -1,6 +1,6 @@
 use crate::config::AppConfig;
 use crate::i18n::{self, I18n, Msg};
-use crate::identity::{self, Usage, UsageResult, UsageWindow};
+use crate::identity::{self, CachedInfo, Usage, UsageResult, UsageWindow};
 
 const BAR_WIDTH: usize = 20;
 
@@ -28,14 +28,14 @@ pub fn run(config: &AppConfig, i18n: &I18n) {
         let acc_dir = config.account_path(acc);
         let is_default = Some(acc.as_str()) == default_acc.as_deref();
         let marker = if is_default { "★" } else { " " };
-        let suffix = email_suffix(identity::read_cache(&acc_dir).and_then(|c| c.email));
+        let suffix = label_suffix(identity::read_cache(&acc_dir));
         println!("  {} {}{}", marker, acc, suffix);
         print_result(identity::fetch_account_usage(&acc_dir), i18n, acc);
     }
 
     if standard_logged_in {
         let cache = identity::read_cache_at(&identity::default_cache_path(&config.base_dir));
-        let suffix = email_suffix(cache.and_then(|c| c.email));
+        let suffix = label_suffix(cache);
         println!("    ~/.claude/{}  {}", suffix, i18n.msg(Msg::ListStandard));
         if let Some(dir) = standard.as_deref() {
             print_result(identity::fetch_account_usage(dir), i18n, "~/.claude/");
@@ -91,11 +91,17 @@ fn reset_label(resets_at: Option<&str>, i18n: &I18n) -> String {
     }
 }
 
-fn email_suffix(email: Option<String>) -> String {
-    match email {
-        Some(e) => format!("  <{}>", e),
-        None => String::new(),
-    }
+/// "  <email>" or "  <email>  Max 20x" from a cached identity. Empty when the
+/// cache has no email (e.g. `doctor` hasn't audited the account yet).
+fn label_suffix(cache: Option<CachedInfo>) -> String {
+    let Some(c) = cache else {
+        return String::new();
+    };
+    let Some(email) = c.email else {
+        return String::new();
+    };
+    let plan = c.plan.map(|p| format!("  {}", p)).unwrap_or_default();
+    format!("  <{}>{}", email, plan)
 }
 
 /// A 20-cell `[████░░░░…]` bar for a 0–100 percentage.
@@ -138,9 +144,36 @@ mod tests {
         assert_eq!(bar(250.0), format!("[{}]", "█".repeat(BAR_WIDTH)));
     }
 
+    fn cache(email: Option<&str>, plan: Option<&str>) -> CachedInfo {
+        CachedInfo {
+            email: email.map(String::from),
+            uuid: None,
+            org: None,
+            fetched_at: None,
+            token_hash: None,
+            plan: plan.map(String::from),
+        }
+    }
+
     #[test]
-    fn email_suffix_formats_and_omits() {
-        assert_eq!(email_suffix(Some("a@b.com".into())), "  <a@b.com>");
-        assert_eq!(email_suffix(None), "");
+    fn label_suffix_email_only() {
+        assert_eq!(
+            label_suffix(Some(cache(Some("a@b.com"), None))),
+            "  <a@b.com>"
+        );
+    }
+
+    #[test]
+    fn label_suffix_email_and_plan() {
+        assert_eq!(
+            label_suffix(Some(cache(Some("a@b.com"), Some("Max 20x")))),
+            "  <a@b.com>  Max 20x"
+        );
+    }
+
+    #[test]
+    fn label_suffix_empty_without_cache_or_email() {
+        assert_eq!(label_suffix(None), "");
+        assert_eq!(label_suffix(Some(cache(None, Some("Max 20x")))), "");
     }
 }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -25,6 +25,9 @@ pub struct Profile {
     pub uuid: Option<String>,
     #[allow(dead_code)]
     pub organization: Option<String>,
+    /// Friendly subscription label, e.g. "Max 20x" / "Pro". `None` when the
+    /// profile carries no recognizable plan.
+    pub plan: Option<String>,
 }
 
 pub enum AuditResult {
@@ -142,6 +145,7 @@ pub struct CachedInfo {
     pub org: Option<String>,
     pub fetched_at: Option<u64>,
     pub token_hash: Option<String>,
+    pub plan: Option<String>,
 }
 
 pub fn read_cache(acc_dir: &Path) -> Option<CachedInfo> {
@@ -160,6 +164,7 @@ pub fn read_cache_at(path: &Path) -> Option<CachedInfo> {
             .get("token_hash")
             .and_then(|x| x.as_str())
             .map(String::from),
+        plan: v.get("plan").and_then(|x| x.as_str()).map(String::from),
     })
 }
 
@@ -174,6 +179,7 @@ fn write_cache_at(path: &Path, profile: &Profile, token: &str) -> std::io::Resul
         "org": profile.organization,
         "fetched_at": now,
         "token_hash": token_hash(token),
+        "plan": profile.plan,
     });
     let serialized = serde_json::to_string_pretty(&body).map_err(std::io::Error::other)?;
     fs::write(path, serialized)
@@ -247,7 +253,53 @@ fn fetch_profile(token: &str) -> Option<Profile> {
             .and_then(|o| o.get("name"))
             .and_then(|n| n.as_str())
             .map(|s| s.to_string()),
+        plan: derive_plan(&v),
     })
+}
+
+/// Build a friendly plan label from a `/oauth/profile` response: "Max 20x",
+/// "Max", "Pro", or `None`. The base tier comes from the boolean flags; the
+/// multiplier (e.g. "20x") is pulled out of `organization.rate_limit_tier`
+/// (e.g. "default_claude_max_20x") when present.
+fn derive_plan(v: &serde_json::Value) -> Option<String> {
+    let account = v.get("account");
+    let has_max = account
+        .and_then(|a| a.get("has_claude_max"))
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false);
+    let has_pro = account
+        .and_then(|a| a.get("has_claude_pro"))
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false);
+    let tier = v
+        .get("organization")
+        .and_then(|o| o.get("rate_limit_tier"))
+        .and_then(|t| t.as_str())
+        .unwrap_or("");
+
+    if has_max {
+        Some(match tier_multiplier(tier) {
+            Some(m) => format!("Max {}", m),
+            None => "Max".to_string(),
+        })
+    } else if has_pro {
+        Some("Pro".to_string())
+    } else {
+        None
+    }
+}
+
+/// Extract a `<digits>x` multiplier token (e.g. "20x") from an underscore-joined
+/// rate-limit tier string. Returns `None` if no such token is present.
+fn tier_multiplier(tier: &str) -> Option<String> {
+    tier.split('_')
+        .find(|tok| {
+            let b = tok.as_bytes();
+            b.len() >= 2
+                && b[b.len() - 1] == b'x'
+                && b[..b.len() - 1].iter().all(u8::is_ascii_digit)
+        })
+        .map(|s| s.to_string())
 }
 
 // --- Usage (5-hour / 7-day rate-limit windows) ---
@@ -481,5 +533,62 @@ mod tests {
     fn iso_to_epoch_rejects_garbage() {
         assert_eq!(iso_to_epoch("not-a-timestamp"), None);
         assert_eq!(iso_to_epoch(""), None);
+    }
+
+    #[test]
+    fn tier_multiplier_extracts_token() {
+        assert_eq!(
+            tier_multiplier("default_claude_max_20x"),
+            Some("20x".to_string())
+        );
+        assert_eq!(
+            tier_multiplier("default_claude_max_5x"),
+            Some("5x".to_string())
+        );
+    }
+
+    #[test]
+    fn tier_multiplier_none_when_absent() {
+        assert_eq!(tier_multiplier("default_claude_pro"), None);
+        assert_eq!(tier_multiplier(""), None);
+        // "x" alone or non-digit prefixes must not match.
+        assert_eq!(tier_multiplier("x"), None);
+        assert_eq!(tier_multiplier("maxx"), None);
+    }
+
+    #[test]
+    fn derive_plan_max_with_multiplier() {
+        let v = serde_json::json!({
+            "account": {"has_claude_max": true, "has_claude_pro": false},
+            "organization": {"rate_limit_tier": "default_claude_max_20x"}
+        });
+        assert_eq!(derive_plan(&v), Some("Max 20x".to_string()));
+    }
+
+    #[test]
+    fn derive_plan_max_without_multiplier() {
+        let v = serde_json::json!({
+            "account": {"has_claude_max": true},
+            "organization": {"rate_limit_tier": "default_claude_max"}
+        });
+        assert_eq!(derive_plan(&v), Some("Max".to_string()));
+    }
+
+    #[test]
+    fn derive_plan_pro() {
+        let v = serde_json::json!({
+            "account": {"has_claude_max": false, "has_claude_pro": true},
+            "organization": {"rate_limit_tier": "default_claude_pro"}
+        });
+        assert_eq!(derive_plan(&v), Some("Pro".to_string()));
+    }
+
+    #[test]
+    fn derive_plan_none_when_neither() {
+        let v = serde_json::json!({
+            "account": {"has_claude_max": false, "has_claude_pro": false},
+            "organization": {}
+        });
+        assert_eq!(derive_plan(&v), None);
     }
 }


### PR DESCRIPTION
## What

Surface each account's Claude subscription plan — `Max 20x` / `Max` / `Pro` — next to its identity, so you can tell at a glance which account is on which tier.

```
$ claude-acc doctor
  ✓ work      alice@anthropic.com  Max 20x  uuid=aa6c22d5-…

$ claude-acc list
  ★ work  (default)  alice@anthropic.com  Max 20x  3d ago

$ claude-acc usage
  ★ work  <alice@anthropic.com>  Max 20x
      5h  [████████░░░░░░░░░░░░]   42%  resets in 2h 14m
```

## Why

Inspired by the plan display in `tku` (`sub`) and `ccam` (`claude-status`) from the gist thread — the one bit of useful identity info those tools showed that this one didn't. It rides along on the `/oauth/profile` call `doctor` **already** makes, so there are **no new API requests**.

## How

Plan is derived from the profile response: `account.has_claude_max` / `has_claude_pro` for the base label, and the `<n>x` multiplier pulled out of `organization.rate_limit_tier` (e.g. `default_claude_max_20x` → `20x`). Omitted when no recognizable subscription.

- **Rust** — `Profile.plan` + `derive_plan`/`tier_multiplier` in `identity.rs`; cached in `.account-info.json` and read back via `CachedInfo.plan`; rendered in `doctor` (human + `--json`), `list`, and the `usage` header. New unit tests cover plan derivation and multiplier extraction (50 tests pass, clippy clean).
- **Shell** — `_claude_acc_identity` emits plan as a 4th tab field; `write_cache` persists it; `doctor` / `doctor --json` / `list` / `usage` render it. Identity parsing moved to tab-IFS `read`. Output verified identical to the Rust CLI.

## Docs

README / README.ru: updated `doctor` / `list` / `usage` examples, plus a new note that **per-account default model already works for free** — each account has its own `settings.json`, so just set its `model` key (no separate feature needed, unlike tools that symlink a shared settings file).

## Note

Builds on the `usage` work from #38 (now merged); the `usage` header reuses the same cached identity. No version bump / CHANGELOG (left to release-please).

🤖 Generated with [Claude Code](https://claude.com/claude-code)