### PR TITLE
fix: emit forward-slash statusLine path on Windows (#49)

### DIFF
--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -148,6 +148,23 @@ fn paint(code: &str, text: &str) -> String {
     }
 }
 
+/// Render `bin` for the `statusLine.command` string.
+///
+/// Claude Code runs the status line command through a shell — on Windows that
+/// shell is Git Bash (`/bin/bash.exe`), where a backslash is an escape
+/// character, so a native `C:\Users\...` path collapses to `C:Users...` and the
+/// binary is never found (the status line silently renders blank). A
+/// forward-slash path (`C:/Users/...`) is understood by both Git Bash and the
+/// Windows API, so it is safe regardless of which shell runs the command.
+fn command_path(bin: &Path) -> String {
+    let s = bin.display().to_string();
+    if cfg!(windows) {
+        s.replace('\\', "/")
+    } else {
+        s
+    }
+}
+
 fn install_into_settings(config: &AppConfig, i18n: &I18n) -> i32 {
     let cwd = std::env::current_dir().unwrap_or_default();
     // The account this directory currently resolves to (managed account or the
@@ -175,7 +192,7 @@ fn install_into_settings(config: &AppConfig, i18n: &I18n) -> i32 {
     let bin = config.base_dir.join("bin").join(binary_name());
     root["statusLine"] = serde_json::json!({
         "type": "command",
-        "command": format!("{} statusline", bin.display()),
+        "command": format!("{} statusline", command_path(&bin)),
         "padding": 0,
     });
 
@@ -229,5 +246,19 @@ mod tests {
     fn paint_respects_no_color() {
         unsafe { std::env::set_var("NO_COLOR", "1") };
         assert_eq!(paint("31", "hi"), "hi");
+    }
+
+    #[test]
+    fn command_path_uses_forward_slashes() {
+        // Whatever the platform, the rendered command must never contain a
+        // backslash — Git Bash (used by Claude Code on Windows) would treat it
+        // as an escape and the status line would render blank.
+        let p = Path::new("base").join("bin").join("claude-acc");
+        let rendered = command_path(&p);
+        assert!(
+            !rendered.contains('\\'),
+            "command path must not contain backslashes: {rendered:?}"
+        );
+        assert!(rendered.contains("bin/claude-acc"), "got {rendered:?}");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #49 — the status line renders **blank** on Windows because `statusline --install` writes a backslash path into `statusLine.command`.

Claude Code runs the status line command through a shell. On Windows (since ~2.1.175) that shell is **Git Bash** (`/bin/bash.exe`), where `\` is an escape character — so `C:\Users\...\claude-acc.exe` collapses to `C:Users...`, the binary isn't found (`exit 127`), and the status line silently renders empty.

## Fix

Render the command path with **forward slashes on Windows**. `C:/Users/...` is understood by both Git Bash and the Windows API, so it's safe regardless of which shell Claude Code uses:

```rust
fn command_path(bin: &Path) -> String {
    let s = bin.display().to_string();
    if cfg!(windows) {
        s.replace('\\', "/")
    } else {
        s
    }
}
```

- **Windows:** `C:\Users\...\claude-acc.exe statusline` → `C:/Users/.../claude-acc.exe statusline`
- **macOS / Linux:** no-op — `cfg!(windows)` is false, paths already use forward slashes, no runtime cost.

Note: `statusline --install` is the only writer of `statusLine.command` in this repo (`install`/`update` don't seed it separately, contrary to the issue's wording), so a single change is sufficient.

## Test plan

- [x] Added `command_path_uses_forward_slashes` — asserts the rendered command never contains a backslash on any platform.
- [x] `cargo test` — all 68 tests pass.
- [x] `cargo clippy` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)