### PR TITLE
fix: run default no longer inherits a linked account's CLAUDE_CONFIG_DIR

### DIFF
--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -821,7 +821,7 @@ _claude_acc_run() {
     shift
 
     if [[ "$name" == "default" ]]; then
-        command claude "$@"
+        ( unset CLAUDE_CONFIG_DIR; command claude "$@" )
         return $?
     fi
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,11 +1,29 @@
 use crate::config::{AppConfig, validate_name};
 use crate::i18n::{I18n, Msg};
+use std::path::Path;
 use std::process::Command;
+
+/// Builds the `claude` invocation for `run`. For the "default" account this
+/// must strip any inherited `CLAUDE_CONFIG_DIR` (e.g. exported by the shell's
+/// directory-link hook) so `claude-acc run default` really runs the standard
+/// ~/.claude/ account rather than whatever the current directory is linked to.
+fn build_command(args: &[String], acc_dir: Option<&Path>) -> Command {
+    let mut cmd = Command::new("claude");
+    cmd.args(args);
+    match acc_dir {
+        Some(dir) => {
+            cmd.env("CLAUDE_CONFIG_DIR", dir);
+        }
+        None => {
+            cmd.env_remove("CLAUDE_CONFIG_DIR");
+        }
+    }
+    cmd
+}
 
 pub fn run(config: &AppConfig, i18n: &I18n, name: &str, args: &[String]) {
     if name == "default" {
-        let status = Command::new("claude")
-            .args(args)
+        let status = build_command(args, None)
             .status()
             .expect("Failed to run claude");
         std::process::exit(status.code().unwrap_or(1));
@@ -22,10 +40,55 @@ pub fn run(config: &AppConfig, i18n: &I18n, name: &str, args: &[String]) {
     }
 
     let acc_dir = config.account_path(name);
-    let status = Command::new("claude")
-        .args(args)
-        .env("CLAUDE_CONFIG_DIR", &acc_dir)
+    let status = build_command(args, Some(&acc_dir))
         .status()
         .expect("Failed to run claude");
     std::process::exit(status.code().unwrap_or(1));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_account_strips_inherited_config_dir() {
+        // Simulate the shell hook having exported CLAUDE_CONFIG_DIR for a
+        // linked directory before `claude-acc run default` is invoked.
+        unsafe {
+            std::env::set_var("CLAUDE_CONFIG_DIR", "/tmp/some-linked-account");
+        }
+
+        let cmd = build_command(&[], None);
+        let removed = cmd
+            .get_envs()
+            .find(|(k, _)| *k == std::ffi::OsStr::new("CLAUDE_CONFIG_DIR"));
+
+        unsafe {
+            std::env::remove_var("CLAUDE_CONFIG_DIR");
+        }
+
+        // env_remove() records the key with a `None` value so the child
+        // process never sees it, regardless of what the parent inherited.
+        assert_eq!(
+            removed,
+            Some((std::ffi::OsStr::new("CLAUDE_CONFIG_DIR"), None))
+        );
+    }
+
+    #[test]
+    fn named_account_sets_config_dir() {
+        let dir = Path::new("/tmp/some-account");
+        let cmd = build_command(&[], Some(dir));
+        let set = cmd
+            .get_envs()
+            .find(|(k, _)| *k == std::ffi::OsStr::new("CLAUDE_CONFIG_DIR"));
+
+        assert_eq!(
+            set,
+            Some((
+                std::ffi::OsStr::new("CLAUDE_CONFIG_DIR"),
+                Some(std::ffi::OsStr::new("/tmp/some-account"))
+            ))
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- `claude-acc run default` ran `claude` without clearing `CLAUDE_CONFIG_DIR`. If the current directory was linked to an account, the shell's chpwd hook (or any prior export) left `CLAUDE_CONFIG_DIR` set in the session, so the "default" run silently launched the linked account instead of the standard `~/.claude/` one.
- Fixed in both the shell function (`_claude_acc_run` in `claude-switch.sh`) and the Rust `run` command (`src/commands/run.rs`) by explicitly clearing `CLAUDE_CONFIG_DIR` before spawning `claude`.
- Audited every other place that takes an account `name` (`add`, `login`, `remove`, `default`, `link`, `clone_settings`, `import`) — all either set `CLAUDE_CONFIG_DIR` explicitly per-account or don't invoke `claude` at all, so this was the only leak.
- `run.rs` now has unit tests covering the command builder for both the "default" (strips the var) and named-account (sets the var) paths.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test --release` (73 passed, including 2 new tests)
- [x] `zsh -n claude-switch.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)