### PR TITLE
fix: run default no longer gets re-activated by the IDE wrapper

### DIFF
--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -821,7 +821,11 @@ _claude_acc_run() {
     shift
 
     if [[ "$name" == "default" ]]; then
-        ( unset CLAUDE_CONFIG_DIR; command claude "$@" )
+        # CLAUDE_ACC_RUN_DEFAULT tells claude-acc's own IDE wrapper (which
+        # `claude` usually resolves to on PATH) not to re-derive
+        # CLAUDE_CONFIG_DIR from $PWD — otherwise it would silently undo
+        # this explicit default run inside a linked directory.
+        ( unset CLAUDE_CONFIG_DIR; CLAUDE_ACC_RUN_DEFAULT=1 command claude "$@" )
         return $?
     fi
 

--- a/shell/claude-wrapper.sh
+++ b/shell/claude-wrapper.sh
@@ -3,9 +3,13 @@
 # Sets CLAUDE_CONFIG_DIR for $PWD via `claude-acc activate`,
 # then exec's the real `claude` binary discovered in PATH.
 
-if [ -z "$CLAUDE_CONFIG_DIR" ]; then
+# CLAUDE_ACC_RUN_DEFAULT marks an explicit `claude-acc run default`: skip
+# re-deriving CLAUDE_CONFIG_DIR from $PWD, since an empty CLAUDE_CONFIG_DIR
+# here means "run the standard account", not "not yet activated".
+if [ -z "$CLAUDE_CONFIG_DIR" ] && [ -z "$CLAUDE_ACC_RUN_DEFAULT" ]; then
     eval "$('__CLAUDE_ACC_BIN__' activate --shell posix 2>/dev/null)"
 fi
+unset CLAUDE_ACC_RUN_DEFAULT
 
 self="$0"
 case "$self" in

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -61,14 +61,22 @@ pub fn run(config: &AppConfig, i18n: &I18n) {
         i18n.print(Msg::InstallCopying(current_version.to_string()));
     }
 
-    fs::copy(&source, &target).expect("Failed to copy binary");
+    // Copy to a temp file in the same directory and rename over `target`
+    // rather than overwriting it in place. In-place overwrite of an
+    // existing executable can leave macOS's cached code-signing validation
+    // for that inode stale, killing the next launch with SIGKILL; a rename
+    // gives the replacement a fresh inode and is atomic on the same filesystem.
+    let tmp = bin_dir.join(format!("{}.new", binary_name()));
+    fs::copy(&source, &tmp).expect("Failed to copy binary");
 
     // Make executable on unix
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&target, fs::Permissions::from_mode(0o755)).ok();
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755)).ok();
     }
+
+    fs::rename(&tmp, &target).expect("Failed to install binary");
 
     i18n.print(Msg::InstallDone(target.to_str().unwrap_or("").to_string()));
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -7,15 +7,23 @@ use std::process::Command;
 /// must strip any inherited `CLAUDE_CONFIG_DIR` (e.g. exported by the shell's
 /// directory-link hook) so `claude-acc run default` really runs the standard
 /// ~/.claude/ account rather than whatever the current directory is linked to.
+///
+/// `claude` on PATH usually resolves to claude-acc's own IDE wrapper
+/// (~/.claude-switch/bin/claude, see src/ide.rs), which re-derives
+/// CLAUDE_CONFIG_DIR from $PWD whenever it finds the var unset — that would
+/// silently undo the "default" request in a linked directory. CLAUDE_ACC_RUN_DEFAULT
+/// tells the wrapper this is an explicit default run so it skips that step.
 fn build_command(args: &[String], acc_dir: Option<&Path>) -> Command {
     let mut cmd = Command::new("claude");
     cmd.args(args);
     match acc_dir {
         Some(dir) => {
             cmd.env("CLAUDE_CONFIG_DIR", dir);
+            cmd.env_remove("CLAUDE_ACC_RUN_DEFAULT");
         }
         None => {
             cmd.env_remove("CLAUDE_CONFIG_DIR");
+            cmd.env("CLAUDE_ACC_RUN_DEFAULT", "1");
         }
     }
     cmd
@@ -76,6 +84,25 @@ mod tests {
     }
 
     #[test]
+    fn default_account_marks_run_default_for_the_ide_wrapper() {
+        // The `claude` on PATH is usually claude-acc's own IDE wrapper,
+        // which re-derives CLAUDE_CONFIG_DIR from $PWD when it sees the var
+        // unset. This marker tells it to skip that for an explicit default run.
+        let cmd = build_command(&[], None);
+        let marker = cmd
+            .get_envs()
+            .find(|(k, _)| *k == std::ffi::OsStr::new("CLAUDE_ACC_RUN_DEFAULT"));
+
+        assert_eq!(
+            marker,
+            Some((
+                std::ffi::OsStr::new("CLAUDE_ACC_RUN_DEFAULT"),
+                Some(std::ffi::OsStr::new("1"))
+            ))
+        );
+    }
+
+    #[test]
     fn named_account_sets_config_dir() {
         let dir = Path::new("/tmp/some-account");
         let cmd = build_command(&[], Some(dir));
@@ -89,6 +116,20 @@ mod tests {
                 std::ffi::OsStr::new("CLAUDE_CONFIG_DIR"),
                 Some(std::ffi::OsStr::new("/tmp/some-account"))
             ))
+        );
+    }
+
+    #[test]
+    fn named_account_clears_run_default_marker() {
+        let dir = Path::new("/tmp/some-account");
+        let cmd = build_command(&[], Some(dir));
+        let marker = cmd
+            .get_envs()
+            .find(|(k, _)| *k == std::ffi::OsStr::new("CLAUDE_ACC_RUN_DEFAULT"));
+
+        assert_eq!(
+            marker,
+            Some((std::ffi::OsStr::new("CLAUDE_ACC_RUN_DEFAULT"), None))
         );
     }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #58. That PR made `claude-acc run default` clear `CLAUDE_CONFIG_DIR` before exec'ing `claude` — but `claude` on PATH usually resolves to claude-acc's own IDE wrapper (`~/.claude-switch/bin/claude`), which re-derives `CLAUDE_CONFIG_DIR` from `$PWD` whenever it sees the var unset. So clearing it was exactly what made the wrapper re-activate the linked account for the current directory, silently undoing the "default" request again.
- Fixed by having `run default` also set `CLAUDE_ACC_RUN_DEFAULT=1`, which tells the wrapper to skip re-derivation for this explicit run. Applied to the shell function (`_claude_acc_run`), the Rust `run` command, and `shell/claude-wrapper.sh`.
- Also fixed `claude-acc install` overwriting the installed binary in place via `fs::copy` — on macOS this can leave a stale code-signing validation cached for that inode, killing the next launch with `SIGKILL` (reproduced this locally while testing). Now copies to a temp file and atomically renames over the target, matching the existing pattern in `update.rs`'s self-update path.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test --release` (75 passed)
- [x] `zsh -n claude-switch.sh`, `bash -n shell/claude-wrapper.sh`
- [x] Manually reproduced against the real wrapper script: temporarily linked a scratch directory to an account, confirmed `run default` without the fix still got re-activated to the linked account, confirmed the fix resolves it — then unlinked the scratch directory again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)