### PR TITLE
fix: run strips auth env vars that can override the selected account

### DIFF
--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -820,12 +820,19 @@ _claude_acc_run() {
     fi
     shift
 
+    # Any of these can override which identity claude actually uses
+    # regardless of CLAUDE_CONFIG_DIR, if they leaked in from the parent
+    # shell — strip them so `run <name>` can't be silently overridden.
     if [[ "$name" == "default" ]]; then
         # CLAUDE_ACC_RUN_DEFAULT tells claude-acc's own IDE wrapper (which
         # `claude` usually resolves to on PATH) not to re-derive
         # CLAUDE_CONFIG_DIR from $PWD — otherwise it would silently undo
         # this explicit default run inside a linked directory.
-        ( unset CLAUDE_CONFIG_DIR; CLAUDE_ACC_RUN_DEFAULT=1 command claude "$@" )
+        (
+            unset CLAUDE_CONFIG_DIR ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN \
+                CLAUDE_CODE_OAUTH_TOKEN AWS_BEARER_TOKEN_BEDROCK
+            CLAUDE_ACC_RUN_DEFAULT=1 command claude "$@"
+        )
         return $?
     fi
 
@@ -837,7 +844,11 @@ _claude_acc_run() {
         return 1
     fi
 
-    CLAUDE_CONFIG_DIR="$acc_dir" command claude "$@"
+    (
+        unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN \
+            CLAUDE_CODE_OAUTH_TOKEN AWS_BEARER_TOKEN_BEDROCK
+        CLAUDE_CONFIG_DIR="$acc_dir" command claude "$@"
+    )
 }
 
 # --- Identity audit (Phase 1: passive, read-only) ---

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,4 +1,5 @@
 use crate::config::{AppConfig, validate_name};
+use crate::environment::strip_claude_auth_env;
 use crate::i18n::{I18n, Msg};
 use std::path::Path;
 use std::process::Command;
@@ -13,6 +14,10 @@ use std::process::Command;
 /// CLAUDE_CONFIG_DIR from $PWD whenever it finds the var unset — that would
 /// silently undo the "default" request in a linked directory. CLAUDE_ACC_RUN_DEFAULT
 /// tells the wrapper this is an explicit default run so it skips that step.
+///
+/// Also strips ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN /
+/// AWS_BEARER_TOKEN_BEDROCK — any of these leaking in from the parent shell can
+/// override which identity claude actually uses, regardless of CLAUDE_CONFIG_DIR.
 fn build_command(args: &[String], acc_dir: Option<&Path>) -> Command {
     let mut cmd = Command::new("claude");
     cmd.args(args);
@@ -26,6 +31,7 @@ fn build_command(args: &[String], acc_dir: Option<&Path>) -> Command {
             cmd.env("CLAUDE_ACC_RUN_DEFAULT", "1");
         }
     }
+    strip_claude_auth_env(&mut cmd);
     cmd
 }
 
@@ -131,5 +137,22 @@ mod tests {
             marker,
             Some((std::ffi::OsStr::new("CLAUDE_ACC_RUN_DEFAULT"), None))
         );
+    }
+
+    #[test]
+    fn strips_auth_env_vars_that_could_override_the_selected_account() {
+        for acc_dir in [None, Some(Path::new("/tmp/some-account"))] {
+            let cmd = build_command(&[], acc_dir);
+            for var in crate::environment::CLAUDE_AUTH_ENV_VARS {
+                let removed = cmd
+                    .get_envs()
+                    .find(|(k, _)| *k == std::ffi::OsStr::new(*var));
+                assert_eq!(
+                    removed,
+                    Some((std::ffi::OsStr::new(*var), None)),
+                    "{var} not stripped for acc_dir={acc_dir:?}"
+                );
+            }
+        }
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,0 +1,45 @@
+// Env vars that let a caller point Claude Code at a *different* identity
+// than CLAUDE_CONFIG_DIR selects — an API key, an OAuth token, or a Bedrock
+// bearer token override which credentials are actually used, regardless of
+// which account's config dir the process was launched with. If any of these
+// leak in from the parent shell, `claude-acc run <name>` can silently target
+// the wrong account even though CLAUDE_CONFIG_DIR itself is set correctly.
+//
+// Mirrors Orca's CLAUDE_AUTH_ENV_VARS (github.com/stablyai/orca,
+// src/main/claude-accounts/environment.ts) — same defensive stripping, ported
+// here after tracing the same class of bug.
+pub const CLAUDE_AUTH_ENV_VARS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "AWS_BEARER_TOKEN_BEDROCK",
+];
+
+/// Removes every var in [`CLAUDE_AUTH_ENV_VARS`] from `cmd`'s environment so
+/// none of them can override the identity `CLAUDE_CONFIG_DIR` selects.
+pub fn strip_claude_auth_env(cmd: &mut std::process::Command) {
+    for var in CLAUDE_AUTH_ENV_VARS {
+        cmd.env_remove(var);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_claude_auth_env_removes_every_listed_var() {
+        let mut cmd = std::process::Command::new("true");
+        for var in CLAUDE_AUTH_ENV_VARS {
+            cmd.env(var, "leaked-value");
+        }
+        strip_claude_auth_env(&mut cmd);
+
+        for var in CLAUDE_AUTH_ENV_VARS {
+            let removed = cmd
+                .get_envs()
+                .find(|(k, _)| *k == std::ffi::OsStr::new(var));
+            assert_eq!(removed, Some((std::ffi::OsStr::new(*var), None)));
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod config;
+mod environment;
 mod i18n;
 mod ide;
 mod identity;


### PR DESCRIPTION
## Summary
- `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN` and `AWS_BEARER_TOKEN_BEDROCK` can each override which identity `claude` actually uses, independent of `CLAUDE_CONFIG_DIR`. If any of these leak in from the parent shell (e.g. a `.env`-loading plugin, or a previous manual export), `claude-acc run <name>` — including `run default` — could silently target a different account than the one requested, on top of `CLAUDE_CONFIG_DIR` being set correctly.
- Prompted by reviewing how [stablyai/orca](https://github.com/stablyai/orca) manages Claude accounts — its `CLAUDE_AUTH_ENV_VARS` / `applyClaudeEnvPatch` (`src/main/claude-accounts/environment.ts`) defend against exactly this class of bug by stripping the same var list before every launch.
- `run` now strips all four before spawning `claude`, in both the Rust command (new `src/environment.rs`, with a `strip_claude_auth_env` helper `run.rs` calls) and the shell function (`_claude_acc_run` in `claude-switch.sh`).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test --release` (77 passed, incl. new `environment::tests` and `commands::run::tests`)
- [x] `zsh -n claude-switch.sh`
- [x] Manually verified against a fake `claude` binary on PATH: exported all four vars, confirmed both `claude-acc run default` (Rust) and the sourced shell function strip them while still setting/clearing `CLAUDE_CONFIG_DIR` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)