### PR TITLE
fix: add/login strip auth env vars before claude auth login

### DIFF
--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -532,7 +532,13 @@ _claude_acc_add() {
     ln -sfn "$HOME/.claude/ide" "$acc_dir/ide"
     (( seed_flag )) && _claude_acc_seed_from_default "$acc_dir"
     _msg add_created "$name"
-    CLAUDE_CONFIG_DIR="$acc_dir" claude auth login
+    # A leaked ANTHROPIC_API_KEY etc. can make `claude auth login` skip the
+    # OAuth flow entirely, or auth a different identity than acc_dir intends.
+    (
+        unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN \
+            CLAUDE_CODE_OAUTH_TOKEN AWS_BEARER_TOKEN_BEDROCK
+        CLAUDE_CONFIG_DIR="$acc_dir" claude auth login
+    )
     echo ""
     _msg add_done
     _msg add_hint_default "$name"
@@ -555,7 +561,13 @@ _claude_acc_login() {
     fi
 
     _msg login_start "$name"
-    CLAUDE_CONFIG_DIR="$acc_dir" claude auth login
+    # A leaked ANTHROPIC_API_KEY etc. can make `claude auth login` skip the
+    # OAuth flow entirely, or auth a different identity than acc_dir intends.
+    (
+        unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN \
+            CLAUDE_CODE_OAUTH_TOKEN AWS_BEARER_TOKEN_BEDROCK
+        CLAUDE_CONFIG_DIR="$acc_dir" claude auth login
+    )
     _msg login_done
 }
 

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,4 +1,5 @@
 use crate::config::{AppConfig, validate_name};
+use crate::environment::strip_claude_auth_env;
 use crate::i18n::{I18n, Msg};
 use crate::ide;
 use crate::identity;
@@ -50,11 +51,14 @@ pub fn run(config: &AppConfig, i18n: &I18n, name: &str, seed_from_default: bool)
     // acc_dir's CLAUDE_CONFIG_DIR — snapshot/restore undoes that collateral.
     // See identity::snapshot_side_effect_keychain for why.
     let keychain_snapshot = identity::snapshot_side_effect_keychain();
-    Command::new("claude")
+    let mut login_cmd = Command::new("claude");
+    login_cmd
         .args(["auth", "login"])
-        .env("CLAUDE_CONFIG_DIR", &acc_dir)
-        .status()
-        .expect("Failed to run claude auth login");
+        .env("CLAUDE_CONFIG_DIR", &acc_dir);
+    // A leaked ANTHROPIC_API_KEY etc. can make `claude auth login` skip the
+    // OAuth flow entirely, or auth a different identity than acc_dir intends.
+    strip_claude_auth_env(&mut login_cmd);
+    login_cmd.status().expect("Failed to run claude auth login");
     identity::restore_side_effect_keychain(keychain_snapshot);
 
     println!();

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,4 +1,5 @@
 use crate::config::{AppConfig, validate_name};
+use crate::environment::strip_claude_auth_env;
 use crate::i18n::{I18n, Msg};
 use crate::identity;
 use std::process::Command;
@@ -20,11 +21,14 @@ pub fn run(config: &AppConfig, i18n: &I18n, name: &str) {
     // clobber the standard account's own Keychain entries as a side effect
     // even when scoped to acc_dir's CLAUDE_CONFIG_DIR.
     let keychain_snapshot = identity::snapshot_side_effect_keychain();
-    Command::new("claude")
+    let mut login_cmd = Command::new("claude");
+    login_cmd
         .args(["auth", "login"])
-        .env("CLAUDE_CONFIG_DIR", &acc_dir)
-        .status()
-        .expect("Failed to run claude auth login");
+        .env("CLAUDE_CONFIG_DIR", &acc_dir);
+    // A leaked ANTHROPIC_API_KEY etc. can make `claude auth login` skip the
+    // OAuth flow entirely, or auth a different identity than acc_dir intends.
+    strip_claude_auth_env(&mut login_cmd);
+    login_cmd.status().expect("Failed to run claude auth login");
     identity::restore_side_effect_keychain(keychain_snapshot);
 
     i18n.print(Msg::LoginDone);


### PR DESCRIPTION
## Summary
- Same class of bug as #61, at the login call site instead of `run`: a leaked `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` / `AWS_BEARER_TOKEN_BEDROCK` from the parent shell can make `claude auth login` skip the OAuth flow entirely, or authenticate a different identity than the `CLAUDE_CONFIG_DIR` it was scoped to intends.
- `add` and `login` now strip these before invoking `claude auth login`, in both the Rust commands (reusing the `strip_claude_auth_env` helper added in #61) and the shell functions (`_claude_acc_add` / `_claude_acc_login`).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test --release` (81 passed)
- [x] `zsh -n claude-switch.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)