### PR TITLE
fix: login accepts "default" and completions offer it for login/run

### DIFF
--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -552,6 +552,22 @@ _claude_acc_login() {
         return 1
     fi
 
+    if [[ "$name" == "default" ]]; then
+        _msg login_start "$name"
+        # Clear any inherited CLAUDE_CONFIG_DIR and tell claude-acc's IDE
+        # wrapper not to re-derive one from $PWD — same reasoning as `run
+        # default`. No keychain snapshot/restore: unlike logging into a
+        # *different* account, this login is meant to change the standard
+        # account's own credentials.
+        (
+            unset CLAUDE_CONFIG_DIR ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN \
+                CLAUDE_CODE_OAUTH_TOKEN AWS_BEARER_TOKEN_BEDROCK
+            CLAUDE_ACC_RUN_DEFAULT=1 claude auth login
+        )
+        _msg login_done
+        return
+    fi
+
     _claude_validate_name "$name" || return 1
 
     local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$name"
@@ -1596,11 +1612,11 @@ _claude_acc_completion() {
         _describe 'command' subcmds
     elif (( CURRENT == 3 )); then
         case "${words[2]}" in
-            login|remove|run|clone-settings)
+            remove|clone-settings)
                 accounts=("$CLAUDE_SWITCH_ACCOUNTS_DIR"/*(N:t))
                 _describe 'account' accounts
                 ;;
-            default|link)
+            default|link|login|run)
                 accounts=("default" "$CLAUDE_SWITCH_ACCOUNTS_DIR"/*(N:t))
                 _describe 'account' accounts
                 ;;

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -32,10 +32,10 @@ _claude_acc_complete() {
         COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status usage statusline update run doctor whoami clone-settings import help" -- "$cur"))
     elif [[ $COMP_CWORD -eq 2 ]]; then
         case "$prev" in
-            login|remove|run|clone-settings)
+            remove|clone-settings)
                 COMPREPLY=($(compgen -W "$('__CLAUDE_ACC_BIN__' completions accounts)" -- "$cur"))
                 ;;
-            default|link)
+            default|link|login|run)
                 COMPREPLY=($(compgen -W "default $('__CLAUDE_ACC_BIN__' completions accounts)" -- "$cur"))
                 ;;
         esac

--- a/shell/init.ps1
+++ b/shell/init.ps1
@@ -35,10 +35,10 @@ Register-ArgumentCompleter -CommandName claude-acc -ScriptBlock {
         $sub = $words[1]
         $accounts = @()
         switch ($sub) {
-            { $_ -in 'login','remove','run','clone-settings' } {
+            { $_ -in 'remove','clone-settings' } {
                 $accounts = (& '__CLAUDE_ACC_BIN__' completions accounts) -split "`n"
             }
-            { $_ -in 'default','link' } {
+            { $_ -in 'default','link','login','run' } {
                 $accounts = @('default') + ((& '__CLAUDE_ACC_BIN__' completions accounts) -split "`n")
             }
         }

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -49,11 +49,11 @@ _claude_acc_completion() {
         _describe 'command' subcmds
     elif (( CURRENT == 3 )); then
         case "${words[2]}" in
-            login|remove|run|clone-settings)
+            remove|clone-settings)
                 accounts=(${(f)"$('__CLAUDE_ACC_BIN__' completions accounts)"})
                 _describe 'account' accounts
                 ;;
-            default|link)
+            default|link|login|run)
                 accounts=('default' ${(f)"$('__CLAUDE_ACC_BIN__' completions accounts)"})
                 _describe 'account' accounts
                 ;;

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -5,6 +5,11 @@ use crate::identity;
 use std::process::Command;
 
 pub fn run(config: &AppConfig, i18n: &I18n, name: &str) {
+    if name == "default" {
+        login_default(i18n);
+        return;
+    }
+
     if !validate_name(name) {
         i18n.print(Msg::NameInvalid);
         std::process::exit(1);
@@ -30,6 +35,24 @@ pub fn run(config: &AppConfig, i18n: &I18n, name: &str) {
     strip_claude_auth_env(&mut login_cmd);
     login_cmd.status().expect("Failed to run claude auth login");
     identity::restore_side_effect_keychain(keychain_snapshot);
+
+    i18n.print(Msg::LoginDone);
+}
+
+/// Re-login the standard `~/.claude` account. No keychain snapshot/restore
+/// here — unlike logging into a *different* account, this login is meant to
+/// change the standard account's own credentials.
+fn login_default(i18n: &I18n) {
+    i18n.print(Msg::LoginStart("default".to_string()));
+    let mut login_cmd = Command::new("claude");
+    login_cmd.args(["auth", "login"]);
+    // Clear any CLAUDE_CONFIG_DIR inherited from a directory link, and tell
+    // claude-acc's IDE wrapper (see src/ide.rs / commands/run.rs) not to
+    // re-derive one from $PWD — same reasoning as `run default`.
+    login_cmd.env_remove("CLAUDE_CONFIG_DIR");
+    login_cmd.env("CLAUDE_ACC_RUN_DEFAULT", "1");
+    strip_claude_auth_env(&mut login_cmd);
+    login_cmd.status().expect("Failed to run claude auth login");
 
     i18n.print(Msg::LoginDone);
 }


### PR DESCRIPTION
## Summary
- `claude-acc login <name>` had no way to re-authenticate the standard `~/.claude` account — `"default"` fell through to `LoginNotFound` since it isn't a managed account dir under `accounts/`.
- `login default` now re-runs `claude auth login` against the standard account directly: clears any inherited `CLAUDE_CONFIG_DIR`, sets `CLAUDE_ACC_RUN_DEFAULT=1` so the IDE wrapper doesn't re-derive one from `$PWD` (same reasoning as `run default`, #59), and — unlike logging into a *different* account — deliberately skips the keychain snapshot/restore from #62, since this login is meant to change the standard account's own credentials.
- Shell completions (zsh/bash/pwsh init templates, plus `claude-switch.sh`'s own legacy completion function) offered `"default"` as a completion for `default`/`link` but not for `login` or `run` — even though `run default` has always been supported. Moved both into the `"default"`-including completion group.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test --release` (81 passed)
- [x] `zsh -n claude-switch.sh`, `zsh -n shell/init.zsh`, `bash -n shell/init.bash`
- [x] Manually verified against a fake `claude` binary on PATH, in both the Rust command and the sourced shell function: `login default` clears `CLAUDE_CONFIG_DIR` and sets `CLAUDE_ACC_RUN_DEFAULT=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)