### PR TITLE
fix: clone-settings rejects "default" with a clear message

### DIFF
--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -828,6 +828,10 @@ _claude_acc_clone_settings() {
         _msg clone_settings_usage
         return 1
     fi
+    if [[ "$name" == "default" ]]; then
+        _msg reserved_name "$name"
+        return 1
+    fi
     _claude_validate_name "$name" || return 1
     local acc_dir="$CLAUDE_SWITCH_ACCOUNTS_DIR/$name"
     if [[ ! -d "$acc_dir" ]]; then

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,4 +1,4 @@
-use crate::config::{AppConfig, validate_name};
+use crate::config::{AppConfig, is_reserved_name, validate_name};
 use crate::environment::strip_claude_auth_env;
 use crate::i18n::{I18n, Msg};
 use crate::ide;
@@ -21,7 +21,7 @@ fn build_login_command(acc_dir: &Path) -> Command {
 }
 
 pub fn run(config: &AppConfig, i18n: &I18n, name: &str, seed_from_default: bool) {
-    if name == "default" {
+    if is_reserved_name(name) {
         i18n.print(Msg::ReservedName(name.to_string()));
         std::process::exit(1);
     }

--- a/src/commands/clone_settings.rs
+++ b/src/commands/clone_settings.rs
@@ -1,8 +1,13 @@
-use crate::config::{AppConfig, validate_name};
+use crate::config::{AppConfig, is_reserved_name, validate_name};
 use crate::i18n::{I18n, Msg};
 use crate::seed;
 
 pub fn run(config: &AppConfig, i18n: &I18n, name: &str) {
+    if is_reserved_name(name) {
+        i18n.print(Msg::ReservedName(name.to_string()));
+        std::process::exit(1);
+    }
+
     if !validate_name(name) {
         i18n.print(Msg::NameInvalid);
         std::process::exit(1);

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::config::{AppConfig, validate_name};
+use crate::config::{AppConfig, is_reserved_name, validate_name};
 use crate::i18n::{I18n, Msg};
 use crate::identity::{self, AuditResult};
 
@@ -13,7 +13,7 @@ use crate::identity::{self, AuditResult};
 // `.credentials.json` fallback travels with the dir on its own.
 
 pub fn run(config: &AppConfig, i18n: &I18n, name: &str, source: &str, move_into: bool) -> i32 {
-    if name == "default" {
+    if is_reserved_name(name) {
         i18n.print(Msg::ReservedName(name.to_string()));
         return 1;
     }

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -1,10 +1,10 @@
-use crate::config::{AppConfig, validate_name};
+use crate::config::{AppConfig, is_reserved_name, validate_name};
 use crate::i18n::{I18n, Msg};
 use std::fs;
 use std::io::{self, Write};
 
 pub fn run(config: &AppConfig, i18n: &I18n, name: &str, force: bool) {
-    if name == "default" {
+    if is_reserved_name(name) {
         i18n.print(Msg::ReservedName(name.to_string()));
         std::process::exit(1);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,14 @@ pub fn validate_name(name: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
+/// Whether `name` is the reserved "default" name — not a real managed
+/// account directory, used across commands to mean "the standard ~/.claude
+/// account". `add`, `remove`, and `clone-settings` reject it as a target
+/// (there's nothing to add/remove/clone-into for the standard account).
+pub fn is_reserved_name(name: &str) -> bool {
+    name == "default"
+}
+
 pub struct AppConfig {
     pub base_dir: PathBuf,
 }
@@ -223,5 +231,13 @@ mod tests {
     fn validate_name_rejects_unicode() {
         assert!(!validate_name("работа"));
         assert!(!validate_name("café"));
+    }
+
+    #[test]
+    fn is_reserved_name_matches_only_default() {
+        assert!(is_reserved_name("default"));
+        assert!(!is_reserved_name("work"));
+        assert!(!is_reserved_name("Default"));
+        assert!(!is_reserved_name(""));
     }
 }


### PR DESCRIPTION
## Summary
Found via a full audit of every place account-name handling could be silently ignoring "default" (prompted by wanting `usage` to also cover the standard account, which — for the record — it already does; that thread turned up a separate, harder keychain-hash-drift issue that's out of scope here).

- `clone-settings <name>` never special-cased `"default"` — it passes `validate_name` (plain alphanumeric), so `clone-settings default` fell through to the generic "not found" message. That's both wrong (default *is* a real, existing thing) and doubly confusing now that `login default` (#65) genuinely works.
- `add`, `remove`, and `import` already did the right thing here, each with their own inline `if name == "default" { ReservedName }` check — `clone-settings` just never got the same treatment.
- Extracted that check into a shared, unit-tested `config::is_reserved_name`, and applied it to `clone-settings` in both the Rust command and `claude-switch.sh`'s shell function. `add`/`remove`/`import` now use the shared helper too instead of duplicating the literal check.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test --release` (89 passed, 1 new: `config::tests::is_reserved_name_matches_only_default`)
- [x] `zsh -n claude-switch.sh`
- [x] Manually verified `clone-settings default` now prints "'default' is a reserved name." instead of "not found", in both the Rust binary and the sourced shell function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)