### PR TITLE
feat: warn (non-blocking) when add/login duplicates an existing account

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -69,6 +69,14 @@ pub fn run(config: &AppConfig, i18n: &I18n, name: &str, seed_from_default: bool)
         .expect("Failed to run claude auth login");
     identity::restore_side_effect_keychain(keychain_snapshot);
 
+    // Best-effort: hint if this login turned out to be the same identity as
+    // an already-known account (a leftover from a prior doctor run's cache —
+    // see identity::find_duplicate_account). Never blocks; just a heads-up.
+    let known = super::known_account_cache_paths(config, name);
+    if let Some(existing) = identity::find_duplicate_account(&acc_dir, &known) {
+        i18n.print(Msg::DuplicateAccountWarning(name.to_string(), existing));
+    }
+
     println!();
     i18n.print(Msg::AddDone);
     i18n.print(Msg::AddHintDefault(name.to_string()));

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -32,7 +32,7 @@ fn build_login_command(acc_dir: Option<&Path>) -> Command {
 
 pub fn run(config: &AppConfig, i18n: &I18n, name: &str) {
     if name == "default" {
-        login_default(i18n);
+        login_default(config, i18n);
         return;
     }
 
@@ -57,19 +57,36 @@ pub fn run(config: &AppConfig, i18n: &I18n, name: &str) {
         .expect("Failed to run claude auth login");
     identity::restore_side_effect_keychain(keychain_snapshot);
 
+    warn_if_duplicate(config, i18n, name, &acc_dir);
+
     i18n.print(Msg::LoginDone);
 }
 
 /// Re-login the standard `~/.claude` account. No keychain snapshot/restore
 /// here — unlike logging into a *different* account, this login is meant to
 /// change the standard account's own credentials.
-fn login_default(i18n: &I18n) {
+fn login_default(config: &AppConfig, i18n: &I18n) {
     i18n.print(Msg::LoginStart("default".to_string()));
     build_login_command(None)
         .status()
         .expect("Failed to run claude auth login");
 
+    if let Some(dir) = identity::standard_token_dir() {
+        warn_if_duplicate(config, i18n, "~/.claude/", &dir);
+    }
+
     i18n.print(Msg::LoginDone);
+}
+
+/// Best-effort: hint if `label`'s just-refreshed login turned out to be the
+/// same identity as an already-known account (from a prior doctor run's
+/// cache — see identity::find_duplicate_account). Never blocks; just a
+/// heads-up.
+fn warn_if_duplicate(config: &AppConfig, i18n: &I18n, label: &str, acc_dir: &std::path::Path) {
+    let known = super::known_account_cache_paths(config, label);
+    if let Some(existing) = identity::find_duplicate_account(acc_dir, &known) {
+        i18n.print(Msg::DuplicateAccountWarning(label.to_string(), existing));
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,3 +20,33 @@ pub mod unlink;
 pub mod update;
 pub mod usage;
 pub mod whoami;
+
+use crate::config::AppConfig;
+use crate::identity;
+use std::path::PathBuf;
+
+/// `(label, cache_path)` pairs for every already-known account except the
+/// one at `exclude_label` — every managed account plus the standard
+/// `~/.claude` account (labeled `"~/.claude/"`). Feeds
+/// `identity::find_duplicate_account`'s `known` argument, used by `add` and
+/// `login` to warn when a freshly-authenticated account turns out to share
+/// an identity with one that already exists.
+fn known_account_cache_paths(config: &AppConfig, exclude_label: &str) -> Vec<(String, PathBuf)> {
+    let mut known: Vec<(String, PathBuf)> = config
+        .list_accounts()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|acc| acc != exclude_label)
+        .map(|acc| {
+            let cache_path = config.account_path(&acc).join(".account-info.json");
+            (acc, cache_path)
+        })
+        .collect();
+    if exclude_label != "~/.claude/" {
+        known.push((
+            "~/.claude/".to_string(),
+            identity::default_cache_path(&config.base_dir),
+        ));
+    }
+    known
+}

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -233,6 +233,18 @@ impl I18n {
             (Msg::DoctorSharedIdentity(ref names), Lang::Ru) => {
                 format!("↔ та же личность, что и {}", names)
             }
+            (Msg::DuplicateAccountWarning(ref new_name, ref existing), Lang::En) => {
+                format!(
+                    "⚠ '{}' looks like the same account as '{}' (same email/uuid) — you now have two config dirs sharing one Claude subscription, not two separate identities.",
+                    new_name, existing
+                )
+            }
+            (Msg::DuplicateAccountWarning(ref new_name, ref existing), Lang::Ru) => {
+                format!(
+                    "⚠ '{}' похож на тот же аккаунт, что и '{}' (совпадают email/uuid) — теперь у вас два конфиг-каталога с одной подпиской Claude, а не два разных аккаунта.",
+                    new_name, existing
+                )
+            }
 
             // import
             (Msg::ImportSourceNotDir(ref p), Lang::En) => {
@@ -391,6 +403,7 @@ pub enum Msg {
     DoctorAllOk,
     DoctorPartial(usize, usize),
     DoctorSharedIdentity(String),
+    DuplicateAccountWarning(String, String),
     RelativeTime(u64),
     SeedCopied(String),
     SeedNothingToCopy,

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -60,6 +60,43 @@ pub fn default_cache_path(switch_dir: &Path) -> PathBuf {
     switch_dir.join("default.account-info.json")
 }
 
+/// Does `(uuid, email)` identify the same account as `cached`? Uuid is the
+/// stable signal and takes priority; email is compared case-insensitively as
+/// a fallback for a `cached` entry that predates uuid caching. Pure — no I/O.
+fn identity_matches(uuid: Option<&str>, email: Option<&str>, cached: &CachedInfo) -> bool {
+    let uuid_match = uuid.is_some() && uuid == cached.uuid.as_deref();
+    if uuid_match {
+        return true;
+    }
+    email.is_some()
+        && email.map(str::to_lowercase) == cached.email.as_deref().map(str::to_lowercase)
+}
+
+/// Best-effort duplicate-account hint: audits `new_dir`'s live identity (also
+/// refreshing its cache, as a side effect of `audit_account`) and compares it
+/// against the *cached* identity of every account in `known` — each
+/// `(label, cache_path)` pair, caller-supplied so it can point at either a
+/// managed account's `.account-info.json` or the standard account's
+/// `default.account-info.json` under whatever label it wants shown (e.g.
+/// "~/.claude/"). Caller must exclude `new_dir` itself from `known`.
+///
+/// Returns the label of the first match, or `None` if `new_dir` can't be
+/// freshly audited (offline / no token) or nothing matches. "Best-effort"
+/// because it only sees accounts a prior `doctor` run cached — one never
+/// audited won't be caught. Mirrors github.com/stablyai/orca's
+/// findDuplicateClaudeAccount, adapted to our CLI's synchronous, cache-based
+/// comparison (no daemon keeping identities warm).
+pub fn find_duplicate_account(new_dir: &Path, known: &[(String, PathBuf)]) -> Option<String> {
+    let AuditResult::Ok(profile) = audit_account(new_dir) else {
+        return None;
+    };
+    known.iter().find_map(|(label, cache_path)| {
+        let cached = read_cache_at(cache_path)?;
+        identity_matches(profile.uuid.as_deref(), profile.email.as_deref(), &cached)
+            .then(|| label.clone())
+    })
+}
+
 fn audit_at(token_dir: &Path, cache_path: &Path) -> AuditResult {
     let Some(token) = read_token(token_dir) else {
         return AuditResult::NoToken;
@@ -786,5 +823,69 @@ mod tests {
             "organization": {}
         });
         assert_eq!(derive_plan(&v), None);
+    }
+
+    fn cached(email: Option<&str>, uuid: Option<&str>) -> CachedInfo {
+        CachedInfo {
+            email: email.map(String::from),
+            uuid: uuid.map(String::from),
+            org: None,
+            fetched_at: None,
+            token_hash: None,
+            plan: None,
+        }
+    }
+
+    #[test]
+    fn identity_matches_by_uuid_regardless_of_email() {
+        let c = cached(Some("old@example.com"), Some("uuid-1"));
+        assert!(identity_matches(
+            Some("uuid-1"),
+            Some("new@example.com"),
+            &c
+        ));
+    }
+
+    #[test]
+    fn identity_matches_by_email_case_insensitively_when_uuid_absent() {
+        let c = cached(Some("Person@Example.com"), None);
+        assert!(identity_matches(None, Some("person@example.com"), &c));
+    }
+
+    #[test]
+    fn identity_matches_prefers_uuid_over_a_conflicting_email() {
+        // A stale cached email shouldn't cause a false mismatch when the
+        // uuid — the stable signal — actually agrees.
+        let c = cached(Some("stale@example.com"), Some("uuid-1"));
+        assert!(identity_matches(
+            Some("uuid-1"),
+            Some("current@example.com"),
+            &c
+        ));
+    }
+
+    #[test]
+    fn identity_matches_false_when_neither_uuid_nor_email_agree() {
+        let c = cached(Some("a@example.com"), Some("uuid-a"));
+        assert!(!identity_matches(Some("uuid-b"), Some("b@example.com"), &c));
+    }
+
+    #[test]
+    fn identity_matches_false_when_nothing_to_compare() {
+        let c = cached(None, None);
+        assert!(!identity_matches(None, None, &c));
+    }
+
+    #[test]
+    fn find_duplicate_account_none_when_new_dir_has_no_token() {
+        let new_dir =
+            std::env::temp_dir().join(format!("claude-acc-test-no-token-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&new_dir);
+        fs::create_dir_all(&new_dir).unwrap();
+
+        let result = find_duplicate_account(&new_dir, &[]);
+
+        let _ = fs::remove_dir_all(&new_dir);
+        assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
## Summary
- Ported [stablyai/orca](https://github.com/stablyai/orca)'s `findDuplicateClaudeAccount` idea, adapted to our CLI's synchronous model: nothing currently stops `claude-acc add foo` and `claude-acc add bar` both logging into the same underlying Claude account, silently splitting one identity across two config-dir "accounts."
- After `add`/`login` (for a managed account or `"default"`, added in #65) finishes its login, best-effort audit the freshly-authenticated identity and compare it against every other account's *cached* identity (from a prior `doctor` run — no extra network calls beyond the one for the account that just logged in). Matches by account uuid, falling back to case-insensitive email.
- On a match, print a warning and continue — **never blocks**. This matches `doctor`'s own existing, explicitly documented stance that sharing one login across config dirs is a legitimate setup (its `DoctorSharedIdentity` neutral cross-reference note) — this PR doesn't change that, it just surfaces the same information one step earlier, at the moment it's most actionable.
- Scoped to Rust only for this pass — `claude-switch.sh`'s parallel identity/cache system would need its own jq-based port; happy to do that as a follow-up if wanted.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test --release` (95 passed, 6 new: `identity::tests::identity_matches_*` (exhaustive coverage of the uuid/email comparison — uuid priority, case-insensitive email fallback, no-match, empty-input) and `find_duplicate_account_none_when_new_dir_has_no_token`)
- [x] `zsh -n claude-switch.sh` (unchanged, still passes)
- [x] Manually ran `add` end-to-end against a fake `claude` binary (no real login) to confirm the new duplicate-check step doesn't crash/regress the happy path when there's nothing to compare against.
- [ ] Full end-to-end verification of the warning actually firing needs two accounts genuinely sharing one identity, which I don't have safely reproducible without a live OAuth login — relying on the unit coverage of the comparison logic instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)