### PR TITLE
feat: update accepts --version for pinning/rollback

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -13,27 +13,61 @@ use crate::i18n::{I18n, Msg};
 const REPO_URL: &str = env!("CARGO_PKG_REPOSITORY");
 const CURRENT: &str = env!("CARGO_PKG_VERSION");
 
-pub fn run(config: &AppConfig, i18n: &I18n, check_only: bool) -> i32 {
+pub fn run(config: &AppConfig, i18n: &I18n, check_only: bool, version: Option<&str>) -> i32 {
     let Some(slug) = repo_slug(REPO_URL) else {
         i18n.print(Msg::UpdateRepoUnknown);
         return 1;
     };
 
-    let Some(tag) = latest_release_tag(&slug) else {
-        i18n.print(Msg::UpdateCheckFailed);
-        return 1;
+    // Pinning to an explicit --version skips the "is this actually newer"
+    // check entirely (below) — that check exists to avoid noisy re-downloads
+    // on every `update` run, but it would also block a deliberate rollback to
+    // an older release, which is the whole point of --version.
+    let (tag, target_version) = match version {
+        Some(v) => {
+            let Some(target_version) = normalize_version(v) else {
+                i18n.print(Msg::UpdateInvalidVersion(v.to_string()));
+                return 1;
+            };
+            let tag = format!("v{target_version}");
+            if !release_tag_exists(&slug, &tag) {
+                i18n.print(Msg::UpdateVersionNotFound(target_version));
+                return 1;
+            }
+            (tag, target_version)
+        }
+        None => {
+            let Some(tag) = latest_release_tag(&slug) else {
+                i18n.print(Msg::UpdateCheckFailed);
+                return 1;
+            };
+            let target_version = tag.trim_start_matches('v').to_string();
+            (tag, target_version)
+        }
     };
-    let latest = tag.trim_start_matches('v');
 
-    if !is_newer(latest, CURRENT) {
+    if target_version == CURRENT {
+        i18n.print(Msg::UpdateUpToDate(CURRENT.to_string()));
+        return 0;
+    }
+    if version.is_none() && !is_newer(&target_version, CURRENT) {
         i18n.print(Msg::UpdateUpToDate(CURRENT.to_string()));
         return 0;
     }
 
-    i18n.print(Msg::UpdateAvailable(
-        CURRENT.to_string(),
-        latest.to_string(),
-    ));
+    if is_newer(&target_version, CURRENT) {
+        i18n.print(Msg::UpdateAvailable(
+            CURRENT.to_string(),
+            target_version.clone(),
+        ));
+    } else {
+        // Only reachable via --version pinning to an older release — the
+        // "is this newer" check above already filtered this out otherwise.
+        i18n.print(Msg::UpdateDowngrading(
+            CURRENT.to_string(),
+            target_version.clone(),
+        ));
+    }
     if check_only {
         return 0;
     }
@@ -55,7 +89,7 @@ pub fn run(config: &AppConfig, i18n: &I18n, check_only: bool) -> i32 {
         "https://github.com/{}/releases/download/{}/{}",
         slug, tag, asset
     );
-    i18n.print(Msg::UpdateDownloading(latest.to_string()));
+    i18n.print(Msg::UpdateDownloading(target_version.clone()));
     if !download(&url, &tmp) {
         let _ = std::fs::remove_file(&tmp);
         i18n.print(Msg::UpdateDownloadFailed);
@@ -75,7 +109,7 @@ pub fn run(config: &AppConfig, i18n: &I18n, check_only: bool) -> i32 {
     }
 
     i18n.print(Msg::UpdateDone(
-        latest.to_string(),
+        target_version,
         target.display().to_string(),
     ));
     0
@@ -127,6 +161,33 @@ fn latest_release_tag(slug: &str) -> Option<String> {
     }
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
     v.get("tag_name")?.as_str().map(String::from)
+}
+
+/// Whether GitHub has a published release for `tag` (e.g. "v0.10.5"). Used
+/// to give a clear "no such version" error for `--version` instead of
+/// letting a bogus version fall through to a confusing download failure.
+fn release_tag_exists(slug: &str, tag: &str) -> bool {
+    let url = format!(
+        "https://api.github.com/repos/{}/releases/tags/{}",
+        slug, tag
+    );
+    Command::new("curl")
+        .args(["-fsSL", "--max-time", "10"])
+        .args(["-H", "User-Agent: claude-acc"])
+        .args(["-H", "Accept: application/vnd.github+json"])
+        .arg(&url)
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// Normalizes a user-supplied `--version` value ("v0.10.5" or "0.10.5") to
+/// the bare "X.Y.Z" form release tags use, validating it parses as a
+/// version at all (catches typos before making any network call).
+fn normalize_version(v: &str) -> Option<String> {
+    let trimmed = v.trim().trim_start_matches('v');
+    parse_version(trimmed)?;
+    Some(trimmed.to_string())
 }
 
 /// "owner/repo" from a GitHub URL (https or scp-style git@), else `None`.
@@ -254,5 +315,23 @@ mod tests {
         assert!(!is_newer("0.7.9", "0.8.0"));
         // Unparseable input is treated as "not newer" (fail safe).
         assert!(!is_newer("garbage", "0.8.0"));
+    }
+
+    #[test]
+    fn normalize_version_strips_leading_v() {
+        assert_eq!(normalize_version("v0.10.5"), Some("0.10.5".to_string()));
+        assert_eq!(normalize_version("0.10.5"), Some("0.10.5".to_string()));
+    }
+
+    #[test]
+    fn normalize_version_trims_whitespace() {
+        assert_eq!(normalize_version("  v0.10.5  "), Some("0.10.5".to_string()));
+    }
+
+    #[test]
+    fn normalize_version_rejects_garbage() {
+        assert_eq!(normalize_version("not-a-version"), None);
+        assert_eq!(normalize_version("1.2"), None);
+        assert_eq!(normalize_version(""), None);
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -281,6 +281,28 @@ impl I18n {
             (Msg::UpdateAvailable(ref cur, ref new), Lang::Ru) => {
                 format!("Доступно обновление: v{} → v{}", cur, new)
             }
+            (Msg::UpdateDowngrading(ref cur, ref target), Lang::En) => {
+                format!("Rolling back: v{} → v{}", cur, target)
+            }
+            (Msg::UpdateDowngrading(ref cur, ref target), Lang::Ru) => {
+                format!("Откатываю: v{} → v{}", cur, target)
+            }
+            (Msg::UpdateInvalidVersion(ref v), Lang::En) => {
+                format!(
+                    "'{}' is not a valid version (expected X.Y.Z, e.g. 0.10.5).",
+                    v
+                )
+            }
+            (Msg::UpdateInvalidVersion(ref v), Lang::Ru) => format!(
+                "'{}' — некорректная версия (ожидается X.Y.Z, например 0.10.5).",
+                v
+            ),
+            (Msg::UpdateVersionNotFound(ref v), Lang::En) => {
+                format!("No release v{} found on GitHub.", v)
+            }
+            (Msg::UpdateVersionNotFound(ref v), Lang::Ru) => {
+                format!("Релиз v{} не найден на GitHub.", v)
+            }
             (Msg::UpdateDownloading(ref v), Lang::En) => format!("Downloading v{}...", v),
             (Msg::UpdateDownloading(ref v), Lang::Ru) => format!("Скачиваю v{}...", v),
             (Msg::UpdateDone(ref v, ref p), Lang::En) => {
@@ -414,6 +436,9 @@ pub enum Msg {
     StatuslineInstallFailed(String),
     UpdateUpToDate(String),
     UpdateAvailable(String, String),
+    UpdateDowngrading(String, String),
+    UpdateInvalidVersion(String),
+    UpdateVersionNotFound(String),
     UpdateDownloading(String),
     UpdateDone(String, String),
     UpdateCheckFailed,

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,10 @@ enum Commands {
         /// Only check whether an update is available; don't download
         #[arg(long)]
         check: bool,
+        /// Install a specific version instead of the latest (e.g. 0.10.5) —
+        /// for rolling back after a bad release
+        #[arg(long)]
+        version: Option<String>,
     },
     /// Output shell activation code (used by shell hook)
     #[command(hide = true)]
@@ -161,9 +165,12 @@ fn main() {
         }
         Some(Commands::Whoami) => commands::whoami::run(&config),
         Some(Commands::Install) => commands::install::run(&config, &i18n),
-        Some(Commands::Update { check }) => {
-            std::process::exit(commands::update::run(&config, &i18n, check))
-        }
+        Some(Commands::Update { check, version }) => std::process::exit(commands::update::run(
+            &config,
+            &i18n,
+            check,
+            version.as_deref(),
+        )),
         Some(Commands::Activate { shell }) => {
             let syntax = match shell.as_str() {
                 "powershell" | "pwsh" => ShellSyntax::PowerShell,


### PR DESCRIPTION
## Summary
- `claude-acc update` only ever installed the latest GitHub release, with no way back if a release turned out bad — the only recourse was manually downloading an older asset and swapping it in by hand.
- `update --version <X.Y.Z>` now installs that specific release instead of latest:
  - Validates the version string up front (clear error, no network call for a typo).
  - Confirms the release actually exists on GitHub (`releases/tags/<tag>`) before attempting anything — a clear "no such version" error instead of a confusing download failure.
  - Skips the "is this newer" freshness gate entirely — the whole point of pinning is to go backward on purpose, which that check would otherwise block.
  - Prints "Rolling back: vX → vY" instead of "Update available: vX → vY" when the target is actually older, so the direction is obvious in the output.
  - Works with `--check` too, for a dry-run (`claude-acc update --check --version 0.10.5`).
- Left `claude-switch.sh`'s `_claude_acc_update` alone — it's a fundamentally different mechanism (always pulls whatever's on `master` right now, no tags/versions/releases involved at all), so there's no equivalent concept to pin there. Consistent with the earlier "Rust only" scoping decision for #70.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test --release` (99 passed, 3 new: `normalize_version_*`)
- [x] `zsh -n claude-switch.sh` (unchanged)
- [x] Ran against the real GitHub API (read-only):
  - `update --check --version 0.10.5` → `Rolling back: v0.11.0 → v0.10.5`
  - `update --check --version garbage` → clear invalid-version error, exit 1
  - `update --check --version 99.99.99` → clear not-found error, exit 1
  - `update --check --version 0.11.0` (current) → `Already on the latest version`
  - `update --check` (no version, existing behavior) → unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)