### PR TITLE
feat: print a passive hint when a newer claude-acc version is out

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,5 +1,6 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::commands::install::binary_name;
 use crate::config::AppConfig;
@@ -12,6 +13,11 @@ use crate::i18n::{I18n, Msg};
 
 const REPO_URL: &str = env!("CARGO_PKG_REPOSITORY");
 const CURRENT: &str = env!("CARGO_PKG_VERSION");
+
+/// How often `maybe_print_hint` is willing to hit the network — once a day,
+/// so the passive hint printed after ordinary commands never adds real
+/// latency to the common case.
+const HINT_CHECK_INTERVAL_SECS: u64 = 24 * 60 * 60;
 
 pub fn run(config: &AppConfig, i18n: &I18n, check_only: bool, version: Option<&str>) -> i32 {
     let Some(slug) = repo_slug(REPO_URL) else {
@@ -190,6 +196,80 @@ fn normalize_version(v: &str) -> Option<String> {
     Some(trimmed.to_string())
 }
 
+fn hint_cache_path(config: &AppConfig) -> PathBuf {
+    config.base_dir.join("update-check.json")
+}
+
+/// `latest: None` means the last attempt failed (network down, API error) —
+/// still recorded, so a persistent outage doesn't turn into a GitHub API
+/// call on every single command for as long as it lasts.
+struct HintCache {
+    checked_at: u64,
+    latest: Option<String>,
+}
+
+fn read_hint_cache(path: &Path) -> Option<HintCache> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&content).ok()?;
+    Some(HintCache {
+        checked_at: v.get("checked_at").and_then(|x| x.as_u64())?,
+        latest: v.get("latest").and_then(|x| x.as_str()).map(String::from),
+    })
+}
+
+fn write_hint_cache(path: &Path, cache: &HintCache) {
+    let body = serde_json::json!({
+        "checked_at": cache.checked_at,
+        "latest": cache.latest,
+    });
+    if let Ok(serialized) = serde_json::to_string(&body) {
+        let _ = std::fs::write(path, serialized);
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Passive "a new version is out" hint, printed after most commands finish.
+/// Checks GitHub Releases at most once every 24h (cached in
+/// `~/.claude-switch/update-check.json`); every other invocation reuses the
+/// cached answer with no network call at all. Silent on any failure — this
+/// is a courtesy nudge, not something that should ever block, slow down, or
+/// error out a command a user is actually trying to run.
+pub fn maybe_print_hint(config: &AppConfig, i18n: &I18n) {
+    let path = hint_cache_path(config);
+    let cached = read_hint_cache(&path);
+    let now = now_secs();
+
+    let latest = match &cached {
+        Some(c) if now.saturating_sub(c.checked_at) < HINT_CHECK_INTERVAL_SECS => c.latest.clone(),
+        _ => {
+            let Some(slug) = repo_slug(REPO_URL) else {
+                return;
+            };
+            let latest = latest_release_tag(&slug).map(|t| t.trim_start_matches('v').to_string());
+            write_hint_cache(
+                &path,
+                &HintCache {
+                    checked_at: now,
+                    latest: latest.clone(),
+                },
+            );
+            latest
+        }
+    };
+
+    if let Some(latest) = latest
+        && is_newer(&latest, CURRENT)
+    {
+        i18n.print(Msg::UpdateHintAvailable(CURRENT.to_string(), latest));
+    }
+}
+
 /// "owner/repo" from a GitHub URL (https or scp-style git@), else `None`.
 fn repo_slug(url: &str) -> Option<String> {
     let s = url.trim().trim_end_matches('/');
@@ -333,5 +413,55 @@ mod tests {
         assert_eq!(normalize_version("not-a-version"), None);
         assert_eq!(normalize_version("1.2"), None);
         assert_eq!(normalize_version(""), None);
+    }
+
+    #[test]
+    fn hint_cache_roundtrips_with_a_version() {
+        let path = std::env::temp_dir().join(format!(
+            "claude-acc-test-hint-cache-with-version-{}.json",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        write_hint_cache(
+            &path,
+            &HintCache {
+                checked_at: 12345,
+                latest: Some("0.11.5".to_string()),
+            },
+        );
+        let read = read_hint_cache(&path).expect("should read back what was written");
+
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(read.checked_at, 12345);
+        assert_eq!(read.latest, Some("0.11.5".to_string()));
+    }
+
+    #[test]
+    fn hint_cache_roundtrips_a_failed_check() {
+        let path = std::env::temp_dir().join(format!(
+            "claude-acc-test-hint-cache-failed-{}.json",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        write_hint_cache(
+            &path,
+            &HintCache {
+                checked_at: 999,
+                latest: None,
+            },
+        );
+        let read = read_hint_cache(&path).expect("should read back what was written");
+
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(read.checked_at, 999);
+        assert_eq!(read.latest, None);
+    }
+
+    #[test]
+    fn read_hint_cache_missing_file_returns_none() {
+        let path = std::path::PathBuf::from("/definitely/does/not/exist/update-check.json");
+        assert!(read_hint_cache(&path).is_none());
     }
 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -13,27 +13,61 @@ use crate::i18n::{I18n, Msg};
 const REPO_URL: &str = env!("CARGO_PKG_REPOSITORY");
 const CURRENT: &str = env!("CARGO_PKG_VERSION");
 
-pub fn run(config: &AppConfig, i18n: &I18n, check_only: bool) -> i32 {
+pub fn run(config: &AppConfig, i18n: &I18n, check_only: bool, version: Option<&str>) -> i32 {
     let Some(slug) = repo_slug(REPO_URL) else {
         i18n.print(Msg::UpdateRepoUnknown);
         return 1;
     };
 
-    let Some(tag) = latest_release_tag(&slug) else {
-        i18n.print(Msg::UpdateCheckFailed);
-        return 1;
+    // Pinning to an explicit --version skips the "is this actually newer"
+    // check entirely (below) — that check exists to avoid noisy re-downloads
+    // on every `update` run, but it would also block a deliberate rollback to
+    // an older release, which is the whole point of --version.
+    let (tag, target_version) = match version {
+        Some(v) => {
+            let Some(target_version) = normalize_version(v) else {
+                i18n.print(Msg::UpdateInvalidVersion(v.to_string()));
+                return 1;
+            };
+            let tag = format!("v{target_version}");
+            if !release_tag_exists(&slug, &tag) {
+                i18n.print(Msg::UpdateVersionNotFound(target_version));
+                return 1;
+            }
+            (tag, target_version)
+        }
+        None => {
+            let Some(tag) = latest_release_tag(&slug) else {
+                i18n.print(Msg::UpdateCheckFailed);
+                return 1;
+            };
+            let target_version = tag.trim_start_matches('v').to_string();
+            (tag, target_version)
+        }
     };
-    let latest = tag.trim_start_matches('v');
 
-    if !is_newer(latest, CURRENT) {
+    if target_version == CURRENT {
+        i18n.print(Msg::UpdateUpToDate(CURRENT.to_string()));
+        return 0;
+    }
+    if version.is_none() && !is_newer(&target_version, CURRENT) {
         i18n.print(Msg::UpdateUpToDate(CURRENT.to_string()));
         return 0;
     }
 
-    i18n.print(Msg::UpdateAvailable(
-        CURRENT.to_string(),
-        latest.to_string(),
-    ));
+    if is_newer(&target_version, CURRENT) {
+        i18n.print(Msg::UpdateAvailable(
+            CURRENT.to_string(),
+            target_version.clone(),
+        ));
+    } else {
+        // Only reachable via --version pinning to an older release — the
+        // "is this newer" check above already filtered this out otherwise.
+        i18n.print(Msg::UpdateDowngrading(
+            CURRENT.to_string(),
+            target_version.clone(),
+        ));
+    }
     if check_only {
         return 0;
     }
@@ -55,7 +89,7 @@ pub fn run(config: &AppConfig, i18n: &I18n, check_only: bool) -> i32 {
         "https://github.com/{}/releases/download/{}/{}",
         slug, tag, asset
     );
-    i18n.print(Msg::UpdateDownloading(latest.to_string()));
+    i18n.print(Msg::UpdateDownloading(target_version.clone()));
     if !download(&url, &tmp) {
         let _ = std::fs::remove_file(&tmp);
         i18n.print(Msg::UpdateDownloadFailed);
@@ -75,7 +109,7 @@ pub fn run(config: &AppConfig, i18n: &I18n, check_only: bool) -> i32 {
     }
 
     i18n.print(Msg::UpdateDone(
-        latest.to_string(),
+        target_version,
         target.display().to_string(),
     ));
     0
@@ -127,6 +161,33 @@ fn latest_release_tag(slug: &str) -> Option<String> {
     }
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
     v.get("tag_name")?.as_str().map(String::from)
+}
+
+/// Whether GitHub has a published release for `tag` (e.g. "v0.10.5"). Used
+/// to give a clear "no such version" error for `--version` instead of
+/// letting a bogus version fall through to a confusing download failure.
+fn release_tag_exists(slug: &str, tag: &str) -> bool {
+    let url = format!(
+        "https://api.github.com/repos/{}/releases/tags/{}",
+        slug, tag
+    );
+    Command::new("curl")
+        .args(["-fsSL", "--max-time", "10"])
+        .args(["-H", "User-Agent: claude-acc"])
+        .args(["-H", "Accept: application/vnd.github+json"])
+        .arg(&url)
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// Normalizes a user-supplied `--version` value ("v0.10.5" or "0.10.5") to
+/// the bare "X.Y.Z" form release tags use, validating it parses as a
+/// version at all (catches typos before making any network call).
+fn normalize_version(v: &str) -> Option<String> {
+    let trimmed = v.trim().trim_start_matches('v');
+    parse_version(trimmed)?;
+    Some(trimmed.to_string())
 }
 
 /// "owner/repo" from a GitHub URL (https or scp-style git@), else `None`.
@@ -254,5 +315,23 @@ mod tests {
         assert!(!is_newer("0.7.9", "0.8.0"));
         // Unparseable input is treated as "not newer" (fail safe).
         assert!(!is_newer("garbage", "0.8.0"));
+    }
+
+    #[test]
+    fn normalize_version_strips_leading_v() {
+        assert_eq!(normalize_version("v0.10.5"), Some("0.10.5".to_string()));
+        assert_eq!(normalize_version("0.10.5"), Some("0.10.5".to_string()));
+    }
+
+    #[test]
+    fn normalize_version_trims_whitespace() {
+        assert_eq!(normalize_version("  v0.10.5  "), Some("0.10.5".to_string()));
+    }
+
+    #[test]
+    fn normalize_version_rejects_garbage() {
+        assert_eq!(normalize_version("not-a-version"), None);
+        assert_eq!(normalize_version("1.2"), None);
+        assert_eq!(normalize_version(""), None);
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -281,6 +281,28 @@ impl I18n {
             (Msg::UpdateAvailable(ref cur, ref new), Lang::Ru) => {
                 format!("Доступно обновление: v{} → v{}", cur, new)
             }
+            (Msg::UpdateDowngrading(ref cur, ref target), Lang::En) => {
+                format!("Rolling back: v{} → v{}", cur, target)
+            }
+            (Msg::UpdateDowngrading(ref cur, ref target), Lang::Ru) => {
+                format!("Откатываю: v{} → v{}", cur, target)
+            }
+            (Msg::UpdateInvalidVersion(ref v), Lang::En) => {
+                format!(
+                    "'{}' is not a valid version (expected X.Y.Z, e.g. 0.10.5).",
+                    v
+                )
+            }
+            (Msg::UpdateInvalidVersion(ref v), Lang::Ru) => format!(
+                "'{}' — некорректная версия (ожидается X.Y.Z, например 0.10.5).",
+                v
+            ),
+            (Msg::UpdateVersionNotFound(ref v), Lang::En) => {
+                format!("No release v{} found on GitHub.", v)
+            }
+            (Msg::UpdateVersionNotFound(ref v), Lang::Ru) => {
+                format!("Релиз v{} не найден на GitHub.", v)
+            }
             (Msg::UpdateDownloading(ref v), Lang::En) => format!("Downloading v{}...", v),
             (Msg::UpdateDownloading(ref v), Lang::Ru) => format!("Скачиваю v{}...", v),
             (Msg::UpdateDone(ref v, ref p), Lang::En) => {
@@ -414,6 +436,9 @@ pub enum Msg {
     StatuslineInstallFailed(String),
     UpdateUpToDate(String),
     UpdateAvailable(String, String),
+    UpdateDowngrading(String, String),
+    UpdateInvalidVersion(String),
+    UpdateVersionNotFound(String),
     UpdateDownloading(String),
     UpdateDone(String, String),
     UpdateCheckFailed,

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -303,6 +303,14 @@ impl I18n {
             (Msg::UpdateVersionNotFound(ref v), Lang::Ru) => {
                 format!("Релиз v{} не найден на GitHub.", v)
             }
+            (Msg::UpdateHintAvailable(ref cur, ref new), Lang::En) => format!(
+                "\nA new version of claude-acc is available: v{} → v{}. Run 'claude-acc update' to update.",
+                cur, new
+            ),
+            (Msg::UpdateHintAvailable(ref cur, ref new), Lang::Ru) => format!(
+                "\nДоступна новая версия claude-acc: v{} → v{}. Обновитесь: claude-acc update.",
+                cur, new
+            ),
             (Msg::UpdateDownloading(ref v), Lang::En) => format!("Downloading v{}...", v),
             (Msg::UpdateDownloading(ref v), Lang::Ru) => format!("Скачиваю v{}...", v),
             (Msg::UpdateDone(ref v, ref p), Lang::En) => {
@@ -439,6 +447,7 @@ pub enum Msg {
     UpdateDowngrading(String, String),
     UpdateInvalidVersion(String),
     UpdateVersionNotFound(String),
+    UpdateHintAvailable(String, String),
     UpdateDownloading(String),
     UpdateDone(String, String),
     UpdateCheckFailed,

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,10 @@ enum Commands {
         /// Only check whether an update is available; don't download
         #[arg(long)]
         check: bool,
+        /// Install a specific version instead of the latest (e.g. 0.10.5) —
+        /// for rolling back after a bad release
+        #[arg(long)]
+        version: Option<String>,
     },
     /// Output shell activation code (used by shell hook)
     #[command(hide = true)]
@@ -161,9 +165,12 @@ fn main() {
         }
         Some(Commands::Whoami) => commands::whoami::run(&config),
         Some(Commands::Install) => commands::install::run(&config, &i18n),
-        Some(Commands::Update { check }) => {
-            std::process::exit(commands::update::run(&config, &i18n, check))
-        }
+        Some(Commands::Update { check, version }) => std::process::exit(commands::update::run(
+            &config,
+            &i18n,
+            check,
+            version.as_deref(),
+        )),
         Some(Commands::Activate { shell }) => {
             let syntax = match shell.as_str() {
                 "powershell" | "pwsh" => ShellSyntax::PowerShell,

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,27 @@ enum Commands {
     Completions { what: String },
 }
 
+/// Whether `command` is safe to follow with the passive "update available"
+/// hint. Excluded: `Activate`/`Init`/`Completions` (their stdout is `eval`'d
+/// or otherwise machine-parsed by the shell integration — extra text would
+/// break it, not just look untidy), `Statusline` (rendered inside Claude
+/// Code's own UI), `Doctor`/`Update` (may run with `--json`, or is already
+/// about updating), and `Run` (hands the terminal to an interactive `claude`
+/// session that can run for hours — a hint printed before it starts would be
+/// stale by the time anyone sees it).
+fn should_show_update_hint(command: &Option<Commands>) -> bool {
+    !matches!(
+        command,
+        Some(Commands::Activate { .. })
+            | Some(Commands::Init { .. })
+            | Some(Commands::Completions { .. })
+            | Some(Commands::Statusline { .. })
+            | Some(Commands::Doctor { .. })
+            | Some(Commands::Update { .. })
+            | Some(Commands::Run { .. })
+    )
+}
+
 fn main() {
     let cli = Cli::parse();
     let config = AppConfig::new();
@@ -128,6 +149,7 @@ fn main() {
         .init()
         .expect("Failed to initialize config directory");
     let i18n = I18n::new();
+    let show_hint = should_show_update_hint(&cli.command);
 
     match cli.command {
         None => {
@@ -180,5 +202,56 @@ fn main() {
         }
         Some(Commands::Init { shell }) => commands::init::run(&shell),
         Some(Commands::Completions { what }) => commands::completions::run(&config, &what),
+    }
+
+    // Only reached by commands that don't std::process::exit internally —
+    // which happens to already exclude Run/Import/error paths too, on top of
+    // the explicit exclusions in should_show_update_hint.
+    if show_hint {
+        commands::update::maybe_print_hint(&config, &i18n);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_hint_excludes_eval_consumed_commands() {
+        assert!(!should_show_update_hint(&Some(Commands::Activate {
+            shell: "posix".to_string()
+        })));
+        assert!(!should_show_update_hint(&Some(Commands::Init {
+            shell: "zsh".to_string()
+        })));
+        assert!(!should_show_update_hint(&Some(Commands::Completions {
+            what: "accounts".to_string()
+        })));
+    }
+
+    #[test]
+    fn update_hint_excludes_statusline_doctor_update_run() {
+        assert!(!should_show_update_hint(&Some(Commands::Statusline {
+            install: false
+        })));
+        assert!(!should_show_update_hint(&Some(Commands::Doctor {
+            json: false
+        })));
+        assert!(!should_show_update_hint(&Some(Commands::Update {
+            check: false,
+            version: None
+        })));
+        assert!(!should_show_update_hint(&Some(Commands::Run {
+            name: "work".to_string(),
+            args: vec![]
+        })));
+    }
+
+    #[test]
+    fn update_hint_shown_for_ordinary_commands() {
+        assert!(should_show_update_hint(&None));
+        assert!(should_show_update_hint(&Some(Commands::List)));
+        assert!(should_show_update_hint(&Some(Commands::Whoami)));
+        assert!(should_show_update_hint(&Some(Commands::Status)));
     }
 }


### PR DESCRIPTION
## Summary
- Nothing told a user a new release existed short of manually running `claude-acc update --check`. Every command that produces ordinary, human-facing output now prints a one-line hint after finishing, when a newer GitHub release is out: `A new version of claude-acc is available: vX → vY. Run 'claude-acc update' to update.`
- Checks GitHub Releases at most once every 24h, cached in `~/.claude-switch/update-check.json` (mirrors `identity.rs`'s cache-file pattern — manual `serde_json::Value` read/write, no `serde` derive dependency added) — every other invocation reuses the cached answer with **zero** network calls. A failed check is cached too, so a persistent outage doesn't turn into a GitHub API call on every single command for as long as it lasts. Silent on any failure — this is a courtesy nudge, never something that blocks or errors out a command.
- Explicitly excluded, via a single `should_show_update_hint` predicate rather than relying on each command's own control flow: `Activate`/`Init`/`Completions` (their stdout is `eval`'d or otherwise machine-parsed by the shell integration — an extra line would actively **break** it, not just look untidy), `Statusline` (renders inside Claude Code's own UI), `Doctor`/`Update` (may run with `--json`, or is already about updating), and `Run` (hands the terminal to an interactive `claude` session that can run for hours — a hint printed before it starts would be stale by the time anyone sees it).
- Built on top of #72 (`update --version`); that PR merged while this one was in flight, so this branch merged `origin/master` to pick it up (manual conflict resolution — same content, different commit hash from the squash-merge, no logic changes).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test --release` (105 passed, 6 new: `hint_cache_*` round-trip tests, `update_hint_*` predicate tests)
- [x] `zsh -n claude-switch.sh` (unchanged — Rust-only, `claude-switch.sh` has no equivalent self-update-check mechanism)
- [x] Manually verified against real output:
  - `claude-acc activate --shell posix` / `init zsh` / `completions accounts` — confirmed byte-for-byte unaffected (no stray line that would break `eval`/completions).
  - Seeded `update-check.json` with a fake newer version, confirmed `list` prints the hint and `doctor` (explicitly excluded) does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)