### PR TITLE
feat: list Claude Code sessions across accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Short version: **cswap** if you want one active account plus automatic rotation 
 | `claude-acc links` | Show all directory links |
 | `claude-acc status` | Show active account |
 | `claude-acc usage` | Show 5h / 7d rate-limit usage for every account |
+| `claude-acc sessions [--all]` | List Claude Code sessions across accounts (current directory by default) |
 | `claude-acc statusline [--install]` | Render (or install) a Claude Code status line with the active account |
 | `claude-acc run <name>` | Run claude under a specific account |
 | `claude-acc whoami` | Print the email (or name) of the active account |
@@ -372,6 +373,37 @@ Claude Code usage:
 ```
 
 Unlike `doctor`, the usage figures are always a live fetch — usage is volatile, so nothing is cached. The email/plan next to each account come from `doctor`'s cache, so run `claude-acc doctor` once to populate them. Accounts with no token show `no token (run: claude-acc login <name>)`; an unreachable API shows `token present, but API unreachable`. Same dependencies and platform caveat as `doctor` (`security`, `curl`, `jq`, `shasum`; macOS only for now).
+
+## Sessions across accounts (`sessions`)
+
+Claude Code stores a conversation as a transcript inside the config directory it was running under:
+
+```
+<CLAUDE_CONFIG_DIR>/projects/<slugified-cwd>/<session-id>.jsonl
+```
+
+Because every account here gets its own `CLAUDE_CONFIG_DIR`, every account also gets its own `projects/` tree. That has a consequence worth knowing: **`claude --resume <id>` only ever sees sessions that belong to the account it runs under.** Start a conversation on `work`, hit a limit, switch to `personal`, and `--resume` won't list it — the transcript is still there, just in the other account's directory.
+
+`claude-acc sessions` shows the whole picture. By default it lists the current directory's sessions across every account; `--all` covers every project:
+
+```
+$ claude-acc sessions
+Sessions for /Users/alice/Documents/my-repo:
+
+  363edaeb-e81c-4021-94f4-7fe7d91815f4  work      just now     9.9 MB
+  0266a566-0336-4055-8f05-c553d368528e  work      15h ago       60 KB  ← newest copy
+  0266a566-0336-4055-8f05-c553d368528e  personal  6d ago        58 KB
+
+The same session id appears in more than one account — those are separate
+copies that have drifted apart. 'claude --resume' only ever sees the copy in
+the account it runs under.
+
+Resume one:  claude-acc run <account> --resume <id>
+```
+
+The same id can exist in more than one account once a transcript has been copied around. Those copies then drift independently, so the listing flags **which one was updated most recently** — that is usually the one you actually want to continue.
+
+The transcript format itself carries no account identity — no email, no user id, no organization uuid (those live in `.claude.json`, which this command never reads or writes). That's why a transcript is portable between accounts at all.
 
 ## Status line
 

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -29,7 +29,7 @@ _claude_acc_complete() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     if [[ $COMP_CWORD -eq 1 ]]; then
-        COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status usage statusline update run doctor whoami clone-settings import help" -- "$cur"))
+        COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status usage sessions statusline update run doctor whoami clone-settings import help" -- "$cur"))
     elif [[ $COMP_CWORD -eq 2 ]]; then
         case "$prev" in
             remove|clone-settings)

--- a/shell/init.ps1
+++ b/shell/init.ps1
@@ -27,7 +27,7 @@ Register-ArgumentCompleter -CommandName claude-acc -ScriptBlock {
     $count = $words.Count
 
     if ($count -le 2) {
-        $cmds = @('list','add','login','remove','default','reset','link','unlink','links','status','usage','statusline','update','run','doctor','whoami','clone-settings','import','help')
+        $cmds = @('list','add','login','remove','default','reset','link','unlink','links','status','usage','sessions','statusline','update','run','doctor','whoami','clone-settings','import','help')
         $cmds | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -37,6 +37,7 @@ _claude_acc_completion() {
         'links:Show all links'
         'status:Current account info'
         'usage:Show 5h / 7d usage for every account'
+        'sessions:List Claude Code sessions across accounts'
         'statusline:Render / install the Claude Code status line'
         'update:Update the binary to the latest release'
         'run:Run claude under a specific account'

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod login;
 pub mod remove;
 pub mod reset;
 pub mod run;
+pub mod sessions;
 pub mod status;
 pub mod statusline;
 pub mod unlink;

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -1,0 +1,176 @@
+use crate::config::AppConfig;
+use crate::i18n::{I18n, Msg};
+use crate::sessions::{self, SessionRef};
+
+pub fn run(config: &AppConfig, i18n: &I18n, all: bool) -> i32 {
+    let cwd = std::env::current_dir().ok();
+    let slug = if all {
+        None
+    } else {
+        cwd.as_deref().map(sessions::project_slug)
+    };
+
+    let found = sessions::list_all(config, slug.as_deref());
+    if found.is_empty() {
+        match (all, &cwd) {
+            (false, Some(dir)) => {
+                i18n.print(Msg::SessionsEmptyHere(dir.display().to_string()));
+            }
+            _ => i18n.print(Msg::SessionsEmpty),
+        }
+        return 0;
+    }
+
+    match (all, &cwd) {
+        (false, Some(dir)) => i18n.print(Msg::SessionsHeader(dir.display().to_string())),
+        _ => i18n.print(Msg::SessionsHeaderAll),
+    }
+    println!();
+
+    let dups = sessions::duplicated_ids(&found);
+    let rows = layout(&found, &dups, i18n);
+    for row in &rows {
+        println!("{}", row);
+    }
+
+    if !dups.is_empty() {
+        println!();
+        i18n.print(Msg::SessionsDuplicateNote);
+    }
+    println!();
+    i18n.print(Msg::SessionsHintResume);
+    0
+}
+
+/// Render one aligned row per session. Sessions whose id lives in more than
+/// one account are marked, and the freshest copy of such an id is flagged —
+/// that is the whole point of the listing: seeing at a glance which account
+/// holds the version you actually want.
+fn layout(found: &[SessionRef], dups: &[String], i18n: &I18n) -> Vec<String> {
+    let acc_width = found.iter().map(|s| s.account.len()).max().unwrap_or(0);
+    let age_cells: Vec<String> = found.iter().map(|s| age_cell(s, i18n)).collect();
+    let age_width = age_cells
+        .iter()
+        .map(|c| c.chars().count())
+        .max()
+        .unwrap_or(0);
+    let newest = newest_per_duplicated_id(found, dups);
+
+    found
+        .iter()
+        .zip(&age_cells)
+        .map(|(s, age)| {
+            let pad = " ".repeat(age_width - age.chars().count());
+            let marker = if newest.contains(&(s.id.as_str(), s.account.as_str())) {
+                format!("  {}", i18n.msg(Msg::SessionsNewestCopy))
+            } else {
+                String::new()
+            };
+            format!(
+                "  {}  {:<acc$}  {}{}  {:>9}{}",
+                s.id,
+                s.account,
+                age,
+                pad,
+                sessions::human_size(s.size),
+                marker,
+                acc = acc_width,
+            )
+        })
+        .collect()
+}
+
+/// `(id, account)` of the freshest copy of every id that exists in more than
+/// one account. Ids present only once are never marked — there is nothing to
+/// choose between.
+fn newest_per_duplicated_id<'a>(
+    found: &'a [SessionRef],
+    dups: &[String],
+) -> Vec<(&'a str, &'a str)> {
+    dups.iter()
+        .filter_map(|id| {
+            found
+                .iter()
+                .filter(|s| &s.id == id)
+                .max_by_key(|s| s.modified)
+                .map(|s| (s.id.as_str(), s.account.as_str()))
+        })
+        .collect()
+}
+
+fn age_cell(s: &SessionRef, i18n: &I18n) -> String {
+    match s.modified {
+        Some(epoch) => i18n.msg(Msg::RelativeTime(sessions::age_secs(epoch))),
+        None => "?".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::i18n::Lang;
+    use std::path::PathBuf;
+
+    fn i18n() -> I18n {
+        I18n { lang: Lang::En }
+    }
+
+    fn session(id: &str, account: &str, modified: u64, size: u64) -> SessionRef {
+        SessionRef {
+            id: id.to_string(),
+            account: account.to_string(),
+            project: "proj".to_string(),
+            path: PathBuf::from(format!("/tmp/{}.jsonl", id)),
+            modified: Some(modified),
+            size,
+        }
+    }
+
+    #[test]
+    fn newest_copy_is_the_one_with_the_latest_mtime() {
+        let found = vec![
+            session("dup", "work", 100, 10),
+            session("dup", "default", 900, 10),
+        ];
+        let newest = newest_per_duplicated_id(&found, &["dup".to_string()]);
+        assert_eq!(newest, vec![("dup", "default")]);
+    }
+
+    #[test]
+    fn unique_ids_are_never_marked_newest() {
+        let found = vec![session("only", "work", 100, 10)];
+        assert!(newest_per_duplicated_id(&found, &[]).is_empty());
+    }
+
+    #[test]
+    fn rows_mark_only_the_freshest_duplicate() {
+        let found = vec![
+            session("dup", "default", 900, 10),
+            session("dup", "work", 100, 10),
+        ];
+        let rows = layout(&found, &["dup".to_string()], &i18n());
+        assert!(rows[0].contains("newest"), "{}", rows[0]);
+        assert!(!rows[1].contains("newest"), "{}", rows[1]);
+    }
+
+    #[test]
+    fn rows_align_account_column_across_differing_name_lengths() {
+        let found = vec![
+            session("a", "work", 900, 10),
+            session("b", "a-very-long-account", 800, 10),
+        ];
+        let rows = layout(&found, &[], &i18n());
+        // Both rows put the age cell at the same column.
+        let at = |r: &String| r.find("ago").expect("age cell present");
+        assert_eq!(at(&rows[0]), at(&rows[1]));
+    }
+
+    #[test]
+    fn rows_show_size_and_account() {
+        let found = vec![session("abc", "work", 900, 2048)];
+        let rows = layout(&found, &[], &i18n());
+        assert!(rows[0].contains("abc"));
+        assert!(rows[0].contains("work"));
+        assert!(rows[0].contains("2 KB"));
+    }
+}

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -367,6 +367,36 @@ impl I18n {
             (Msg::UsageResetsIn(ref d), Lang::Ru) => format!("сброс через {}", d),
             (Msg::UsageAvailableNow, Lang::En) => s("available now"),
             (Msg::UsageAvailableNow, Lang::Ru) => s("доступно сейчас"),
+
+            // sessions
+            (Msg::SessionsHeader(ref dir), Lang::En) => format!("Sessions for {}:", dir),
+            (Msg::SessionsHeader(ref dir), Lang::Ru) => format!("Сессии для {}:", dir),
+            (Msg::SessionsHeaderAll, Lang::En) => s("Sessions across all projects:"),
+            (Msg::SessionsHeaderAll, Lang::Ru) => s("Сессии по всем проектам:"),
+            (Msg::SessionsEmpty, Lang::En) => s("No sessions found."),
+            (Msg::SessionsEmpty, Lang::Ru) => s("Сессии не найдены."),
+            (Msg::SessionsEmptyHere(ref dir), Lang::En) => format!(
+                "No sessions for {}.\nUse 'claude-acc sessions --all' to list every project.",
+                dir
+            ),
+            (Msg::SessionsEmptyHere(ref dir), Lang::Ru) => format!(
+                "Нет сессий для {}.\nПосмотреть все проекты: 'claude-acc sessions --all'.",
+                dir
+            ),
+            (Msg::SessionsNewestCopy, Lang::En) => s("← newest copy"),
+            (Msg::SessionsNewestCopy, Lang::Ru) => s("← свежая копия"),
+            (Msg::SessionsDuplicateNote, Lang::En) => s(
+                "The same session id appears in more than one account — those are separate\ncopies that have drifted apart. 'claude --resume' only ever sees the copy in\nthe account it runs under.",
+            ),
+            (Msg::SessionsDuplicateNote, Lang::Ru) => s(
+                "Один и тот же id сессии есть в нескольких аккаунтах — это отдельные копии,\nкоторые разошлись. 'claude --resume' видит только копию того аккаунта, под\nкоторым запущен.",
+            ),
+            (Msg::SessionsHintResume, Lang::En) => {
+                s("Resume one:  claude-acc run <account> --resume <id>")
+            }
+            (Msg::SessionsHintResume, Lang::Ru) => {
+                s("Продолжить:  claude-acc run <account> --resume <id>")
+            }
         }
     }
 
@@ -461,6 +491,13 @@ pub enum Msg {
     ImportDone(String, String),
     ImportRekeyed,
     ImportVerified(String),
+    SessionsHeader(String),
+    SessionsHeaderAll,
+    SessionsEmpty,
+    SessionsEmptyHere(String),
+    SessionsNewestCopy,
+    SessionsDuplicateNote,
+    SessionsHintResume,
 }
 
 fn relative_time(secs: u64, lang: Lang) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod ide;
 mod identity;
 mod resolve;
 mod seed;
+mod sessions;
 
 use clap::{Parser, Subcommand};
 use commands::activate::ShellSyntax;
@@ -86,6 +87,16 @@ enum Commands {
         /// Extra arguments passed to claude
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
+    },
+    /// List Claude Code sessions across accounts
+    ///
+    /// Shows the current directory's sessions by default. A session lives in
+    /// the account it was created under, so the same id can exist as separate
+    /// copies in several accounts — the newest copy of each is flagged.
+    Sessions {
+        /// List sessions from every project, not just the current directory
+        #[arg(long)]
+        all: bool,
     },
     /// Audit each account's actual OAuth identity (email, UUID)
     Doctor {
@@ -182,6 +193,9 @@ fn main() {
             std::process::exit(commands::statusline::run(&config, &i18n, install))
         }
         Some(Commands::Run { name, args }) => commands::run::run(&config, &i18n, &name, &args),
+        Some(Commands::Sessions { all }) => {
+            std::process::exit(commands::sessions::run(&config, &i18n, all))
+        }
         Some(Commands::Doctor { json }) => {
             std::process::exit(commands::doctor::run(&config, &i18n, json))
         }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,0 +1,297 @@
+//! Locating Claude Code session transcripts across accounts.
+//!
+//! Claude Code writes one session as
+//! `<CLAUDE_CONFIG_DIR>/projects/<slug>/<uuid>.jsonl`, plus an optional
+//! sidecar directory `<slug>/<uuid>/` holding subagent transcripts. Because
+//! this tool gives every account its own `CLAUDE_CONFIG_DIR`, each account
+//! also gets its own `projects/` tree — which is exactly why a session
+//! started under one account is invisible to `claude --resume` under another.
+//!
+//! The transcript format itself carries no account identity (no email, no
+//! user id, no organization uuid — those live in `.claude.json`, which we
+//! never touch), so a transcript is portable between accounts as a plain
+//! file copy.
+
+use crate::config::AppConfig;
+use crate::identity;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Label used for the standard `~/.claude` account, matching the `default`
+/// name the other commands accept.
+pub const DEFAULT_LABEL: &str = "default";
+
+/// One session transcript belonging to one account.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionRef {
+    /// Session uuid — the `<id>` in `claude --resume <id>`.
+    pub id: String,
+    /// Account label this copy lives in ("default" for the standard account).
+    pub account: String,
+    /// The `projects/` subdirectory name (the slugified working directory).
+    pub project: String,
+    /// Path to the `.jsonl` transcript itself.
+    pub path: PathBuf,
+    /// Last-modified time, Unix epoch seconds. `None` if unreadable.
+    pub modified: Option<u64>,
+    /// Transcript size in bytes.
+    pub size: u64,
+}
+
+/// Slugify a working directory the way Claude Code names its `projects/`
+/// subdirectories: every non-alphanumeric character becomes `-`.
+///
+/// Inferred from the on-disk layout rather than documented, and verified
+/// against a sample of real project directories (paths containing `/`, `.`
+/// and `-` all round-trip). Callers that must not silently show an empty
+/// list should offer an "all projects" fallback.
+pub fn project_slug(cwd: &Path) -> String {
+    cwd.to_string_lossy()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}
+
+/// The `projects/` tree inside one account's config directory.
+pub fn projects_dir(config_dir: &Path) -> PathBuf {
+    config_dir.join("projects")
+}
+
+/// `(label, config_dir)` for every account this tool knows about: each
+/// managed account, plus the standard `~/.claude` account as "default".
+/// Accounts whose directory doesn't exist are skipped.
+pub fn account_config_dirs(config: &AppConfig) -> Vec<(String, PathBuf)> {
+    let mut dirs: Vec<(String, PathBuf)> = config
+        .list_accounts()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|acc| {
+            let dir = config.account_path(&acc);
+            (acc, dir)
+        })
+        .collect();
+    if let Some(dir) = identity::standard_token_dir()
+        && dir.is_dir()
+    {
+        dirs.push((DEFAULT_LABEL.to_string(), dir));
+    }
+    dirs
+}
+
+/// Every session in one account, newest first. `slug` restricts the search to
+/// a single project; `None` walks every project in that account.
+pub fn list_in(config_dir: &Path, account: &str, slug: Option<&str>) -> Vec<SessionRef> {
+    let root = projects_dir(config_dir);
+    let project_dirs: Vec<PathBuf> = match slug {
+        Some(s) => vec![root.join(s)],
+        None => match fs::read_dir(&root) {
+            Ok(entries) => entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+                .map(|e| e.path())
+                .collect(),
+            Err(_) => return Vec::new(),
+        },
+    };
+
+    let mut found = Vec::new();
+    for dir in project_dirs {
+        let project = match dir.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let Some(id) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let meta = entry.metadata().ok();
+            found.push(SessionRef {
+                id: id.to_string(),
+                account: account.to_string(),
+                project: project.clone(),
+                path: path.clone(),
+                modified: meta.as_ref().and_then(modified_epoch),
+                size: meta.as_ref().map(|m| m.len()).unwrap_or(0),
+            });
+        }
+    }
+    sort_newest_first(&mut found);
+    found
+}
+
+/// Every session across every account, newest first.
+pub fn list_all(config: &AppConfig, slug: Option<&str>) -> Vec<SessionRef> {
+    let mut found: Vec<SessionRef> = account_config_dirs(config)
+        .iter()
+        .flat_map(|(label, dir)| list_in(dir, label, slug))
+        .collect();
+    sort_newest_first(&mut found);
+    found
+}
+
+/// Sort newest first, with unreadable timestamps last and a stable
+/// account/id tiebreak so identical mtimes don't reorder between runs.
+pub fn sort_newest_first(sessions: &mut [SessionRef]) {
+    sessions.sort_by(|a, b| {
+        b.modified
+            .cmp(&a.modified)
+            .then_with(|| a.account.cmp(&b.account))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+}
+
+/// Ids that appear in more than one account — the sessions where "which copy
+/// do you mean?" is a real question.
+pub fn duplicated_ids(sessions: &[SessionRef]) -> Vec<String> {
+    let mut ids: Vec<&str> = sessions.iter().map(|s| s.id.as_str()).collect();
+    ids.sort_unstable();
+    let mut dups: Vec<String> = Vec::new();
+    for pair in ids.windows(2) {
+        if pair[0] == pair[1] && dups.last().map(String::as_str) != Some(pair[0]) {
+            dups.push(pair[0].to_string());
+        }
+    }
+    dups
+}
+
+fn modified_epoch(meta: &fs::Metadata) -> Option<u64> {
+    meta.modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
+/// Seconds between `epoch` and now. Returns 0 for timestamps in the future
+/// (clock skew), so callers can render "just now" rather than a negative age.
+pub fn age_secs(epoch: u64) -> u64 {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    now.saturating_sub(epoch)
+}
+
+/// Byte count as a short human string: `"918 B"`, `"61 KB"`, `"9.2 MB"`.
+pub fn human_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    if bytes < KB {
+        format!("{} B", bytes)
+    } else if bytes < MB {
+        format!("{} KB", bytes / KB)
+    } else if bytes < GB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_slug_replaces_separators() {
+        assert_eq!(
+            project_slug(Path::new("/Users/me/Documents/my-repo")),
+            "-Users-me-Documents-my-repo"
+        );
+    }
+
+    #[test]
+    fn project_slug_replaces_dots_and_underscores() {
+        // A git worktree under `.worktrees/` is the common real case.
+        assert_eq!(
+            project_slug(Path::new("/home/me/rpg-game/.worktrees/ai")),
+            "-home-me-rpg-game--worktrees-ai"
+        );
+        assert_eq!(project_slug(Path::new("/tmp/a_b")), "-tmp-a-b");
+    }
+
+    fn session(id: &str, account: &str, modified: u64) -> SessionRef {
+        SessionRef {
+            id: id.to_string(),
+            account: account.to_string(),
+            project: "proj".to_string(),
+            path: PathBuf::from(format!("/tmp/projects/proj/{}.jsonl", id)),
+            modified: Some(modified),
+            size: 0,
+        }
+    }
+
+    #[test]
+    fn sort_puts_newest_first() {
+        let mut v = vec![
+            session("a", "work", 100),
+            session("b", "work", 300),
+            session("c", "work", 200),
+        ];
+        sort_newest_first(&mut v);
+        let ids: Vec<&str> = v.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["b", "c", "a"]);
+    }
+
+    #[test]
+    fn sort_puts_unknown_timestamps_last() {
+        let mut unknown = session("x", "work", 0);
+        unknown.modified = None;
+        let mut v = vec![unknown, session("a", "work", 100)];
+        sort_newest_first(&mut v);
+        assert_eq!(v[0].id, "a");
+        assert_eq!(v[1].id, "x");
+    }
+
+    #[test]
+    fn duplicated_ids_finds_ids_present_in_two_accounts() {
+        let v = vec![
+            session("same", "work", 100),
+            session("same", "default", 200),
+            session("only-here", "work", 300),
+        ];
+        assert_eq!(duplicated_ids(&v), vec!["same".to_string()]);
+    }
+
+    #[test]
+    fn duplicated_ids_reports_each_id_once() {
+        let v = vec![
+            session("same", "work", 100),
+            session("same", "default", 200),
+            session("same", "other", 300),
+        ];
+        assert_eq!(duplicated_ids(&v), vec!["same".to_string()]);
+    }
+
+    #[test]
+    fn duplicated_ids_empty_when_all_unique() {
+        let v = vec![session("a", "work", 100), session("b", "default", 200)];
+        assert!(duplicated_ids(&v).is_empty());
+    }
+
+    #[test]
+    fn human_size_units() {
+        assert_eq!(human_size(918), "918 B");
+        assert_eq!(human_size(62445), "60 KB");
+        assert_eq!(human_size(9_685_413), "9.2 MB");
+        assert_eq!(human_size(3_221_225_472), "3.0 GB");
+    }
+
+    #[test]
+    fn age_secs_clamps_future_timestamps() {
+        let future = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 10_000;
+        assert_eq!(age_secs(future), 0);
+    }
+}


### PR DESCRIPTION
## Why

Each account gets its own `CLAUDE_CONFIG_DIR`, so each also gets its own `projects/` tree. Consequence: **`claude --resume <id>` only ever sees sessions belonging to the account it runs under.** Start a conversation on `work`, hit a limit, switch to `personal` — `--resume` won't list it. The transcript is still on disk, just in the other account's directory, with nothing to tell you it exists.

## What

`claude-acc sessions` lists the current directory's sessions across every account (`--all` for every project), newest first:

```
$ claude-acc sessions
Sessions for /Users/alice/Documents/my-repo:

  363edaeb-e81c-4021-94f4-7fe7d91815f4  work      just now     9.9 MB
  0266a566-0336-4055-8f05-c553d368528e  work      15h ago       60 KB  ← newest copy
  0266a566-0336-4055-8f05-c553d368528e  personal  6d ago        58 KB

The same session id appears in more than one account — those are separate
copies that have drifted apart. 'claude --resume' only ever sees the copy in
the account it runs under.

Resume one:  claude-acc run <account> --resume <id>
```

Once a transcript has been copied between accounts the copies drift independently, so the listing flags **which copy was updated most recently** — usually the one you actually want to continue.

## How

New `src/sessions.rs` as the shared lookup layer, so later work (copying a session between accounts) builds on the same primitives:

- `project_slug()` — slugifies a cwd the way Claude Code names its `projects/` subdirectories (every non-alphanumeric character becomes `-`). This rule is inferred from the on-disk layout rather than documented, so it was verified against a sample of 40 real project directories: all round-trip, including paths containing `.` (git worktrees under `.worktrees/`). `--all` is the fallback if it ever drifts.
- `account_config_dirs()` — every managed account plus the standard `~/.claude` one, labeled `default`.
- `list_in()` / `list_all()` / `duplicated_ids()` / `sort_newest_first()`.

Worth noting: the transcript format carries **no account identity** — no email, no user id, no organization uuid (those live in `.claude.json`, which this command never touches). Verified by walking every key of a real transcript. That's what makes a transcript portable between accounts in the first place.

## Scope

Read-only. Nothing is copied, moved, or written.

## Tests

14 new unit tests (119 total, was 105): slug derivation, sort ordering including unreadable timestamps, duplicate detection, size formatting, future-timestamp clamping, and row layout (column alignment, newest-copy marking).

Also verified end-to-end against a real duplicated session, then cleaned up.

## Docs

README: command table entry plus a "Sessions across accounts" section explaining the per-account `projects/` tree and why `--resume` can't see across accounts. Shell completions updated for zsh/bash/PowerShell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)