### PR TITLE
feat: complete every command's arguments and flags

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -38,3 +38,17 @@ jobs:
           zsh -n shell/init.zsh
           bash -n shell/init.bash
           bash -n shell/claude-wrapper.sh
+
+      # init.ps1 is `eval`'d by PowerShell users' profiles, so a syntax error
+      # there breaks their shell startup. pwsh is preinstalled on the runner.
+      - name: Syntax-check the PowerShell template
+        shell: pwsh
+        run: |
+          $errors = $null
+          $null = [System.Management.Automation.Language.Parser]::ParseFile(
+              (Resolve-Path shell/init.ps1).Path, [ref]$null, [ref]$errors)
+          if ($errors) {
+              $errors | ForEach-Object { Write-Error $_.Message }
+              exit 1
+          }
+          Write-Output "shell/init.ps1 parses cleanly"

--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ JetBrains IDEs (PhpStorm, IntelliJ etc.) and VSCode launch the `claude` binary d
 
 No manual setup required — `claude-acc install` does both. New accounts created via `claude-acc add` get their `ide/` symlink automatically.
 
+## Shell completions
+
+`claude-acc install` also wires up Tab completion for zsh, bash and PowerShell. It covers every command and its arguments — account names (with `default` where the command accepts it), `session copy` ids for the current directory, `resume-hook on|off`, `import`'s path, and each command's flags:
+
+```
+$ claude-acc session copy <TAB>
+363edaeb-e81c-4021-94f4-7fe7d91815f4  0266a566-0336-4055-8f05-c553d368528e
+
+$ claude-acc session copy 0266a566-… --to <TAB>
+default  personal  work
+```
+
+Session ids are scoped to the current directory on purpose: a full listing runs to hundreds of uuids across every project ever opened, which is not a menu anyone can pick from.
+
 ## What gets switched
 
 `CLAUDE_CONFIG_DIR` relocates the entire `~/.claude/` directory, including ([docs](https://code.claude.com/docs/en/settings)):

--- a/README.ru.md
+++ b/README.ru.md
@@ -201,6 +201,20 @@ JetBrains IDE (PhpStorm, IntelliJ и т.п.) и VSCode запускают `claud
 
 Никаких ручных шагов не нужно — `claude-acc install` делает обе вещи. Новые аккаунты, создаваемые через `claude-acc add`, получают `ide/` symlink автоматически.
 
+## Автодополнение в оболочке
+
+`claude-acc install` заодно настраивает автодополнение по Tab для zsh, bash и PowerShell. Оно покрывает все команды и их аргументы — имена аккаунтов (с `default` там, где команда его принимает), id сессий для `session copy` в текущей директории, `resume-hook on|off`, путь для `import` и флаги каждой команды:
+
+```
+$ claude-acc session copy <TAB>
+363edaeb-e81c-4021-94f4-7fe7d91815f4  0266a566-0336-4055-8f05-c553d368528e
+
+$ claude-acc session copy 0266a566-… --to <TAB>
+default  personal  work
+```
+
+Id сессий намеренно ограничены текущей директорией: полный список — это сотни uuid по всем проектам, которые вы когда-либо открывали, и выбрать из такого меню невозможно.
+
 ## Что переключается
 
 `CLAUDE_CONFIG_DIR` перемещает всю директорию `~/.claude/`, включая ([docs](https://code.claude.com/docs/en/settings)):

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -25,18 +25,66 @@ __claude_acc_activate
 
 # Completions
 _claude_acc_complete() {
-    local cur prev
+    local cur prev cmd sub accounts
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
+    cmd="${COMP_WORDS[1]}"
+    sub="${COMP_WORDS[2]}"
+
     if [[ $COMP_CWORD -eq 1 ]]; then
-        COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status usage sessions session resume-hook statusline update run doctor whoami clone-settings import help" -- "$cur"))
-    elif [[ $COMP_CWORD -eq 2 ]]; then
-        case "$prev" in
+        COMPREPLY=($(compgen -W "list add login remove default reset link unlink links status usage sessions session resume-hook statusline update install run doctor whoami clone-settings import help" -- "$cur"))
+        return
+    fi
+
+    # The value of a flag that takes one, whatever word number it lands on.
+    case "$prev" in
+        --to|--from)
+            # `default` is not a managed account directory but every command
+            # taking an account name accepts it as the standard ~/.claude one.
+            COMPREPLY=($(compgen -W "default $('__CLAUDE_ACC_BIN__' completions accounts)" -- "$cur"))
+            return
+            ;;
+        --version)
+            return
+            ;;
+    esac
+
+    if [[ "$cur" == -* ]]; then
+        case "$cmd" in
+            add) COMPREPLY=($(compgen -W "--seed -s" -- "$cur")) ;;
+            remove) COMPREPLY=($(compgen -W "--force -f" -- "$cur")) ;;
+            import) COMPREPLY=($(compgen -W "--move" -- "$cur")) ;;
+            statusline) COMPREPLY=($(compgen -W "--install" -- "$cur")) ;;
+            sessions) COMPREPLY=($(compgen -W "--all" -- "$cur")) ;;
+            doctor) COMPREPLY=($(compgen -W "--json" -- "$cur")) ;;
+            update) COMPREPLY=($(compgen -W "--check --version" -- "$cur")) ;;
+            session) COMPREPLY=($(compgen -W "--to --from --force -f" -- "$cur")) ;;
+        esac
+        return
+    fi
+
+    if [[ $COMP_CWORD -eq 2 ]]; then
+        case "$cmd" in
             remove|clone-settings)
                 COMPREPLY=($(compgen -W "$('__CLAUDE_ACC_BIN__' completions accounts)" -- "$cur"))
                 ;;
             default|link|login|run)
                 COMPREPLY=($(compgen -W "default $('__CLAUDE_ACC_BIN__' completions accounts)" -- "$cur"))
+                ;;
+            session)
+                COMPREPLY=($(compgen -W "copy" -- "$cur"))
+                ;;
+            resume-hook)
+                COMPREPLY=($(compgen -W "on off" -- "$cur"))
+                ;;
+        esac
+    elif [[ $COMP_CWORD -eq 3 ]]; then
+        case "$cmd" in
+            # `import <name> <path>`: the name is new, the path exists.
+            import) COMPREPLY=($(compgen -d -- "$cur")) ;;
+            session)
+                [[ "$sub" == copy ]] &&
+                    COMPREPLY=($(compgen -W "$('__CLAUDE_ACC_BIN__' completions sessions)" -- "$cur"))
                 ;;
         esac
     fi

--- a/shell/init.ps1
+++ b/shell/init.ps1
@@ -26,24 +26,48 @@ Register-ArgumentCompleter -CommandName claude-acc -ScriptBlock {
     $words = $commandAst.ToString() -split '\s+'
     $count = $words.Count
 
+    $cmd = if ($count -ge 2) { $words[1] } else { '' }
+    $sub = if ($count -ge 3) { $words[2] } else { '' }
+    $prev = if ($count -ge 2) { $words[$count - 2] } else { '' }
+    # `default` is not a managed account directory, but every command taking
+    # an account name accepts it as "the standard ~/.claude one".
+    $accountsWithDefault = { @('default') + ((& '__CLAUDE_ACC_BIN__' completions accounts) -split "`n") }
+    $candidates = @()
+
     if ($count -le 2) {
-        $cmds = @('list','add','login','remove','default','reset','link','unlink','links','status','usage','sessions','session','resume-hook','statusline','update','run','doctor','whoami','clone-settings','import','help')
-        $cmds | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
-            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        $candidates = @('list','add','login','remove','default','reset','link','unlink','links','status','usage','sessions','session','resume-hook','statusline','update','install','run','doctor','whoami','clone-settings','import','help')
+    } elseif ($prev -in '--to','--from') {
+        # The value of a flag that takes one, whatever word number it is on.
+        $candidates = & $accountsWithDefault
+    } elseif ($prev -eq '--version') {
+        $candidates = @()
+    } elseif ($wordToComplete -like '-*') {
+        switch ($cmd) {
+            'add'        { $candidates = @('--seed','-s') }
+            'remove'     { $candidates = @('--force','-f') }
+            'import'     { $candidates = @('--move') }
+            'statusline' { $candidates = @('--install') }
+            'sessions'   { $candidates = @('--all') }
+            'doctor'     { $candidates = @('--json') }
+            'update'     { $candidates = @('--check','--version') }
+            'session'    { $candidates = @('--to','--from','--force','-f') }
         }
     } elseif ($count -eq 3) {
-        $sub = $words[1]
-        $accounts = @()
-        switch ($sub) {
+        switch ($cmd) {
             { $_ -in 'remove','clone-settings' } {
-                $accounts = (& '__CLAUDE_ACC_BIN__' completions accounts) -split "`n"
+                $candidates = (& '__CLAUDE_ACC_BIN__' completions accounts) -split "`n"
             }
             { $_ -in 'default','link','login','run' } {
-                $accounts = @('default') + ((& '__CLAUDE_ACC_BIN__' completions accounts) -split "`n")
+                $candidates = & $accountsWithDefault
             }
+            'session'     { $candidates = @('copy') }
+            'resume-hook' { $candidates = @('on','off') }
         }
-        $accounts | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
-            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
-        }
+    } elseif ($count -eq 4 -and $cmd -eq 'session' -and $sub -eq 'copy') {
+        $candidates = (& '__CLAUDE_ACC_BIN__' completions sessions) -split "`n"
+    }
+
+    $candidates | Where-Object { $_ -and $_ -like "$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
     }
 }

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -23,8 +23,17 @@ add-zsh-hook chpwd _claude_chpwd_hook
 __claude_acc_activate
 
 # Completions
+_claude_acc_accounts() {
+    local -a accounts
+    accounts=(${(f)"$('__CLAUDE_ACC_BIN__' completions accounts)"})
+    # `default` is not a managed account directory but every command that
+    # takes an account name accepts it as "the standard ~/.claude one".
+    [[ -n "$1" ]] && accounts=('default' $accounts)
+    _describe 'account' accounts
+}
+
 _claude_acc_completion() {
-    local -a subcmds accounts
+    local -a subcmds flags states subsubs sessions
     subcmds=(
         'list:List accounts'
         'add:Add account'
@@ -38,27 +47,80 @@ _claude_acc_completion() {
         'status:Current account info'
         'usage:Show 5h / 7d usage for every account'
         'sessions:List Claude Code sessions across accounts'
-        'session:Copy a session into another account'
+        'session:Work with a single session transcript'
         'resume-hook:Toggle the --resume check in the claude wrapper'
         'statusline:Render / install the Claude Code status line'
         'update:Update the binary to the latest release'
+        'install:Install binary and shell integration'
         'run:Run claude under a specific account'
         'doctor:Audit each account OAuth identity'
         'whoami:Print active account email'
         'clone-settings:Copy ~/.claude/ config into account'
         'import:Import an existing Claude config dir (no re-login)'
     )
+
+    local cmd="${words[2]}"
+    local cur="${words[CURRENT]}"
+    local prev="${words[CURRENT-1]}"
+
     if (( CURRENT == 2 )); then
         _describe 'command' subcmds
-    elif (( CURRENT == 3 )); then
-        case "${words[2]}" in
+        return
+    fi
+
+    # The value of a flag that takes one. Checked before anything positional:
+    # `--to <TAB>` wants an account, whatever word number it lands on.
+    case "$prev" in
+        --to|--from)
+            _claude_acc_accounts with-default
+            return
+            ;;
+        --version)
+            return
+            ;;
+    esac
+
+    if [[ "$cur" == -* ]]; then
+        case "$cmd" in
+            add) flags=('--seed:Seed the new account from ~/.claude/' '-s:Seed the new account from ~/.claude/') ;;
+            remove) flags=('--force:Skip confirmation' '-f:Skip confirmation') ;;
+            import) flags=('--move:Move the directory instead of copying it') ;;
+            statusline) flags=('--install:Write the statusLine config into settings.json') ;;
+            sessions) flags=('--all:Every project, not just this directory') ;;
+            doctor) flags=('--json:Output as JSON') ;;
+            update) flags=('--check:Only check, do not download' '--version:Install a specific version') ;;
+            session) flags=('--to:Destination account' '--from:Source account' '--force:Skip confirmation' '-f:Skip confirmation') ;;
+        esac
+        (( ${#flags} )) && _describe 'option' flags
+        return
+    fi
+
+    if (( CURRENT == 3 )); then
+        case "$cmd" in
             remove|clone-settings)
-                accounts=(${(f)"$('__CLAUDE_ACC_BIN__' completions accounts)"})
-                _describe 'account' accounts
+                _claude_acc_accounts
                 ;;
             default|link|login|run)
-                accounts=('default' ${(f)"$('__CLAUDE_ACC_BIN__' completions accounts)"})
-                _describe 'account' accounts
+                _claude_acc_accounts with-default
+                ;;
+            session)
+                subsubs=('copy:Copy a session into another account')
+                _describe 'subcommand' subsubs
+                ;;
+            resume-hook)
+                states=('on:Check --resume in the claude wrapper' 'off:Pass --resume straight through')
+                _describe 'state' states
+                ;;
+        esac
+    elif (( CURRENT == 4 )); then
+        case "$cmd" in
+            # `import <name> <path>`: the name is new, the path exists.
+            import) _files -/ ;;
+            session)
+                if [[ "${words[3]}" == copy ]]; then
+                    sessions=(${(f)"$('__CLAUDE_ACC_BIN__' completions sessions)"})
+                    _describe 'session' sessions
+                fi
                 ;;
         esac
     fi

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,10 +1,81 @@
 use crate::config::AppConfig;
+use crate::sessions;
 
+/// Data for the shell completion functions, one item per line. Everything
+/// here is read by `$(...)` in a completion hook, so it stays plain and
+/// silent: an unknown `what` prints nothing rather than an error, since a
+/// stray message would end up offered as a completion candidate.
 pub fn run(config: &AppConfig, what: &str) {
-    if what == "accounts" {
-        let accounts = config.list_accounts().unwrap_or_default();
-        for acc in accounts {
-            println!("{}", acc);
+    match what {
+        "accounts" => {
+            for acc in config.list_accounts().unwrap_or_default() {
+                println!("{}", acc);
+            }
         }
+        "sessions" => {
+            for id in session_ids(config) {
+                println!("{}", id);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Session ids for the current directory, newest first, each listed once
+/// however many accounts hold a copy.
+///
+/// Scoped to the current project on purpose: a full listing runs to hundreds
+/// of uuids across every project ever opened, which is not a menu anyone can
+/// pick from. The ids you might plausibly want to resume or copy right now
+/// are the ones belonging to where you are.
+fn session_ids(config: &AppConfig) -> Vec<String> {
+    let Ok(cwd) = std::env::current_dir() else {
+        return Vec::new();
+    };
+    let slug = sessions::project_slug(&cwd);
+    dedup_keeping_order(
+        sessions::list_all(config, Some(&slug))
+            .into_iter()
+            .map(|s| s.id),
+    )
+}
+
+/// Deduplicate while preserving first-seen order — the input is already
+/// sorted newest first, and sorting again by id would throw that away.
+fn dedup_keeping_order(items: impl Iterator<Item = String>) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for item in items {
+        if !seen.contains(&item) {
+            seen.push(item);
+        }
+    }
+    seen
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(v: &[&str]) -> Vec<String> {
+        dedup_keeping_order(v.iter().map(|s| s.to_string()))
+    }
+
+    #[test]
+    fn dedup_keeps_the_first_occurrence_of_each_id() {
+        // Same session in two accounts must be offered once.
+        assert_eq!(ids(&["a", "b", "a"]), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn dedup_preserves_newest_first_order() {
+        assert_eq!(
+            ids(&["newest", "older", "oldest"]),
+            vec!["newest", "older", "oldest"]
+        );
+    }
+
+    #[test]
+    fn dedup_of_nothing_is_nothing() {
+        assert!(ids(&[]).is_empty());
     }
 }


### PR DESCRIPTION
Requested before cutting 0.14.0, so the release ships with completion for what it adds.

## The gap

Tab completion covered account names for six commands (`remove`, `clone-settings`, `default`, `link`, `login`, `run`) and nothing else. Everything added since — `sessions`, `session copy`, `resume-hook` — had none, and **no command had ever completed a flag**. `install` wasn't even in the command list.

## Coverage now

Went through all 22 commands. Every argument and flag that can be completed, is:

| | completes |
|---|---|
| `session <TAB>` | `copy` |
| `session copy <TAB>` | session ids for this directory |
| `--to` / `--from <TAB>` | accounts + `default`, wherever on the line they appear |
| `resume-hook <TAB>` | `on` / `off` |
| `import <name> <TAB>` | directories |
| `add -<TAB>` | `--seed` `-s` |
| `remove -<TAB>` | `--force` `-f` |
| `import -<TAB>` | `--move` |
| `statusline -<TAB>` | `--install` |
| `sessions -<TAB>` | `--all` |
| `doctor -<TAB>` | `--json` |
| `update -<TAB>` | `--check` `--version` |
| `session -<TAB>` | `--to` `--from` `--force` `-f` |

Commands that take nothing (`list`, `reset`, `unlink`, `links`, `status`, `usage`, `whoami`, `install`) correctly offer nothing. Hidden commands (`activate`, `init`, `completions`) stay hidden. `default default` is offered because it's real — it resets to `~/.claude/`.

## `completions sessions`

New, and deliberately scoped to the **current directory's** project. A full listing is hundreds of uuids across every project ever opened, which is not a menu anyone can pick from. Ids are deduplicated — a session held by two accounts is offered once — and keep their newest-first order rather than being re-sorted by uuid.

## CI: `shell/init.ps1` was never syntax-checked

The Shell workflow checks `init.zsh`, `init.bash` and the wrapper, but never `init.ps1` — which PowerShell users `eval` from their profile, so a typo there breaks their shell startup. Tolerable when it was a dozen lines; not now that this PR triples it. Added a parse step (`pwsh` is preinstalled on the runner).

## Verification

The Rust side has 3 new unit tests for the dedup helper (157 total, was 154).

Shell completions can't be unit-tested in this repo, so I exercised both scripts by stubbing their completion primitives (`_describe`/`_files` in zsh, `COMPREPLY` in bash) and calling the functions with real `words`/`CURRENT` and `COMP_WORDS`/`COMP_CWORD` values — every row of the table above, plus the no-op cases. `init.ps1` was parse-checked locally with `pwsh` before adding the CI step.

## Docs

Completions weren't mentioned in either README at all. Both now have a short "Shell completions" section, including why session ids are directory-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)