### PR TITLE
chore: add agent rules for the mistakes we keep making

### DIFF
--- a/.claude/rules/cli-completions.md
+++ b/.claude/rules/cli-completions.md
@@ -1,0 +1,49 @@
+---
+paths:
+  - "src/main.rs"
+  - "src/commands/completions.rs"
+  - "shell/init.zsh"
+  - "shell/init.bash"
+  - "shell/init.ps1"
+---
+
+# A new command isn't done until it completes
+
+Adding a command, subcommand, flag, or positional argument to the CLI means
+touching all three completion scripts in the same commit — not just `main.rs`:
+
+- `shell/init.zsh`
+- `shell/init.bash`
+- `shell/init.ps1`
+
+All three, every time. A command that completes in zsh but not bash is worse
+than one that completes nowhere, because the gap looks like a bug in the shell.
+
+Cover everything a user can type after the command name: the name itself, its
+positional arguments, and its flags.
+
+## Values the tool already knows
+
+If an argument takes a value that exists somewhere in the program — account
+names, session ids — serve it from `src/commands/completions.rs`
+(`claude-acc completions <what>`) instead of hardcoding a list in three
+different shells.
+
+Keep any such list scoped to something a human can pick from. Session ids are
+deliberately limited to the current directory's project: the full set is
+hundreds of uuids across every project ever opened.
+
+## Also
+
+Add the command to the table in **both** READMEs — see `readme-parity.md`.
+
+## Verifying
+
+Completion scripts have no unit tests here, and CI only checks that they parse
+(`zsh -n`, `bash -n`, and a PowerShell parse of `init.ps1`). To check behaviour,
+stub the shells' completion primitives and call the function directly:
+
+- zsh — override `_describe` and `_files`, set `words` and `CURRENT`
+- bash — set `COMP_WORDS` and `COMP_CWORD`, read back `COMPREPLY`
+
+Walk every branch you added, including the ones that should offer nothing.

--- a/.claude/rules/commits-and-prs.md
+++ b/.claude/rules/commits-and-prs.md
@@ -1,0 +1,62 @@
+# Commit messages set the version — and the PR title is the commit message
+
+This repo squash-merges. The PR title becomes the single commit on `master`
+verbatim, and `release-please` reads it to build the changelog and pick the
+next version. **Nothing in CI validates it.** A wrong prefix is silent, and
+once merged the tag and changelog are already generated from it.
+
+Get it wrong and:
+
+- `chore:` on a user-facing fix → absent from the changelog, no version bump;
+  the fix ships invisibly, and nobody knows to upgrade
+- `feat:` on a fix → a minor bump that promises a feature there isn't one
+- a breaking change without `!` → ships as a minor, and upgrades break
+
+So the PR title is not a summary you dash off. It is the release note.
+
+## The prefixes this repo uses
+
+Configured in `release-please-config.json`:
+
+| Prefix | Bump | Changelog |
+| --- | --- | --- |
+| `feat:` | minor | **Features** |
+| `fix:` | patch | **Bug Fixes** |
+| `perf:` | patch | **Performance** |
+| `docs:` | patch | **Documentation** |
+| `refactor:` | patch | **Refactors** |
+| `revert:` | patch | **Reverts** |
+| `chore:` `ci:` `build:` `test:` `style:` | patch | hidden |
+| any + `!`, or `BREAKING CHANGE:` in the body | **major** | highlighted |
+
+Pick by what the change does **for a user**, not by how it felt to write. A
+one-line change that fixes broken behaviour is `fix:`. A large refactor nobody
+can observe is `refactor:`.
+
+Write the subject in the imperative and lowercase after the prefix, as an
+actual sentence about the change: `fix: refresh the claude wrapper on update`,
+not `fix: wrapper bug`.
+
+## One topic per PR
+
+One problem, or one feature, per PR. Not two related ones, not "while I was in
+there".
+
+A PR that does two things cannot be reviewed as either, cannot be reverted
+without taking the other with it, and gets one changelog line for two changes
+— so one of them is invisible to whoever reads the release notes.
+
+If a change turns out to need a second, unrelated fix to work, that is two
+PRs, the second stacked on the first. Say so in the description.
+
+Noticing something unrelated mid-change is normal. Note it, finish what you're
+doing, do it separately.
+
+## History
+
+Add commits as work progresses. Never `--amend` anything already pushed, never
+force-push a branch under review — the branch history is how a reviewer sees
+what changed after their comments. Squash-merge collapses it at the end, so
+extra commits cost nothing.
+
+To bring a branch up to date, **merge** `master` into it. Never rebase.

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -1,0 +1,47 @@
+---
+paths:
+  - "src/*.rs"
+  - "src/commands/*.rs"
+---
+
+# User-facing text goes through `i18n`, always
+
+Every string a person reads — messages, prompts, errors, hints — is a `Msg`
+variant in `src/i18n.rs` with an arm for **every** language, printed via
+`i18n.print(...)` or `i18n.msg(...)`.
+
+Never `println!` or `eprintln!` prose directly. It compiles, it looks fine in
+English, and it is simply untranslated forever — nothing in the build or in CI
+will tell you. Half the users get a command whose output is half in their
+language and half not.
+
+## Adding a message
+
+1. Add the variant to `enum Msg` (carry the interpolated values as fields —
+   `Msg::SessionCopied(String, String, String, String)`, not a pre-formatted
+   `String`)
+2. Add one match arm per language. The match is exhaustive over `(Msg, Lang)`,
+   so a missing arm is a compile error — do not paper over it with a `_`
+   catch-all, which is exactly how a language silently stops being covered
+3. Print it with `i18n.print(...)`, or compose with `i18n.msg(...)`
+
+Keep the wording of each language natural rather than word-for-word. These are
+messages someone reads under pressure, not a translation exercise.
+
+## The narrow exceptions
+
+Direct printing is right only for output that is **not prose for a human**:
+
+- machine-consumed output — `activate` emits shell code to be `eval`'d,
+  `completions` emits one candidate per line, `--json` emits JSON
+- an error prefix carrying an OS message that has no translation anyway
+  (`eprintln!("seed: {}", e)`)
+
+If you are reaching for one of these, it should be obvious which. "It's just a
+short string" is not one of them.
+
+## Also
+
+New messages usually mean new sample output in the docs — see
+`readme-parity.md`, which requires translated console samples to come from a
+real run rather than a hand translation.

--- a/.claude/rules/readme-parity.md
+++ b/.claude/rules/readme-parity.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "README.md"
+  - "README.ru.md"
+---
+
+# Both READMEs, or neither
+
+`README.md` (English) and `README.ru.md` (Russian) are peers, not an original
+and a translation allowed to lag. Change one, change the other **in the same
+commit** — same sections, same order, same placement, same command table rows.
+
+A docs-only catch-up PR afterwards is not a fix: between the two, a released
+version shipped with a README that lied to half its readers.
+
+## Russian console examples must be real output
+
+Never hand-translate a sample block from the English README. Run the command
+with `CLAUDE_ACC_LANG=ru` and paste what it actually printed.
+
+Translated-by-hand samples drift from `src/i18n.rs` the moment a string
+changes, and nothing in CI will ever catch it.
+
+## Checklist
+
+- [ ] Same new/edited section exists in both files, in the same position
+- [ ] Command table updated in both, if a command changed
+- [ ] Every `ru` sample block came from a real `CLAUDE_ACC_LANG=ru` run
+- [ ] Anchors used in links exist in that file's own language
+      (`#ide-integration` vs `#интеграция-с-ide`)

--- a/.claude/rules/readme-parity.md
+++ b/.claude/rules/readme-parity.md
@@ -1,30 +1,39 @@
 ---
 paths:
-  - "README.md"
-  - "README.ru.md"
+  - "README*.md"
 ---
 
-# Both READMEs, or neither
+# Every README, or none
 
-`README.md` (English) and `README.ru.md` (Russian) are peers, not an original
-and a translation allowed to lag. Change one, change the other **in the same
-commit** — same sections, same order, same placement, same command table rows.
+The `README*.md` files are peers — no original, no translation allowed to lag.
+Change one, change **all of them, in the same commit**: same sections, same
+order, same placement, same command table rows.
+
+Today that is `README.md` (English) and `README.ru.md` (Russian). Check what
+is actually on disk rather than trusting that list — this rule applies to
+whatever `README*.md` matches, including a language added after it was
+written.
 
 A docs-only catch-up PR afterwards is not a fix: between the two, a released
-version shipped with a README that lied to half its readers.
+version shipped with a README that lied to some of its readers.
 
-## Russian console examples must be real output
+## Translated console examples must be real output
 
 Never hand-translate a sample block from the English README. Run the command
-with `CLAUDE_ACC_LANG=ru` and paste what it actually printed.
+under that language and paste what it actually printed:
 
-Translated-by-hand samples drift from `src/i18n.rs` the moment a string
-changes, and nothing in CI will ever catch it.
+```sh
+CLAUDE_ACC_LANG=ru claude-acc sessions
+```
+
+`CLAUDE_ACC_LANG` takes the same codes as `src/i18n.rs` knows. Hand-translated
+samples drift from the real strings the moment one changes, and nothing in CI
+will ever catch it.
 
 ## Checklist
 
-- [ ] Same new/edited section exists in both files, in the same position
-- [ ] Command table updated in both, if a command changed
-- [ ] Every `ru` sample block came from a real `CLAUDE_ACC_LANG=ru` run
-- [ ] Anchors used in links exist in that file's own language
+- [ ] The new or edited section exists in **every** `README*.md`, same position
+- [ ] Command table updated in each, if a command changed
+- [ ] Every translated sample block came from a real run in that language
+- [ ] Anchors in links exist in that file's own language
       (`#ide-integration` vs `#интеграция-с-ide`)

--- a/.claude/rules/shell-parity.md
+++ b/.claude/rules/shell-parity.md
@@ -1,0 +1,59 @@
+---
+paths:
+  - "src/main.rs"
+  - "src/commands/*.rs"
+  - "claude-switch.sh"
+---
+
+# Keep the zsh script in step with the Rust CLI
+
+`claude-switch.sh` (macOS / zsh, sourced from `~/.zshrc`) is a real, supported
+way to use this tool, not a deprecated leftover. People run it today.
+
+## Bug fixes: always, no test to apply
+
+**A bug fix in behaviour the script also implements gets fixed in the script
+too. Every time, same PR.** There is nothing to weigh here.
+
+The bug exists in both. Fixing one side means shipping a changelog entry and a
+release that say it's fixed while half the users still hit it — which is worse
+than not having fixed it at all, because now nobody will look again.
+
+Before you call a fix done, ask: does `claude-switch.sh` have this code path?
+If yes, it has the bug, and it is part of the fix.
+
+## Features: if it can be supported without trouble, it must be
+
+Port it in the same PR as the Rust change. That is the whole test — not "is it
+worth it", not "will anyone notice". If the script can do it without a fight,
+it does it.
+
+"Without trouble" means the script already has the machinery: it reads the same
+`~/.claude-switch/` layout, calls the same `security` / `curl` / `jq`, and
+prints the same kinds of messages. Most command and flag changes land here.
+
+## When it genuinely can't
+
+Only when porting would mean reimplementing a substantial Rust subsystem in
+zsh, or the feature depends on machinery the script has no equivalent for.
+
+Then say so **explicitly in the PR description, with the reason**. Skipping is
+a decision that gets written down, never a silent omission.
+
+## Where the two already differ
+
+The script implements 18 commands. Absent for the reasons above:
+
+| Command | Why it's Rust-only |
+| --- | --- |
+| `statusline` | renders from JSON on stdin |
+| `sessions` | needs the cross-account `projects/` walk |
+| `session copy` | same, plus the copy and sidecar machinery |
+| `resume-hook` | the script generates its own `claude` wrapper |
+| `install` | the script is sourced, never installed |
+
+Adding a row is allowed. Adding one silently is not.
+
+## Before pushing
+
+If you touched `claude-switch.sh`, CI runs `zsh -n` on it. Run it locally too.

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -1,0 +1,74 @@
+---
+paths:
+  - "src/*.rs"
+  - "src/commands/*.rs"
+---
+
+# Almost every code change ships a test proving it works
+
+The default is a test, in the same PR. Not a follow-up PR, not "this one is
+too small". If you changed what the program does, there is a test showing it
+now does it — one that fails without your change.
+
+#61, #62, #64 and #65 all merged with no tests at all, and needed #66 to catch
+up afterwards. By then the untested code had already been released.
+
+## The exceptions are narrow, and this isn't one of them
+
+A change may go without a test only when it provably cannot alter behaviour:
+
+- comments, doc comments, README, PR text
+- a rename or a move with no logic change
+- formatting, or a mechanical `cargo clippy --fix`
+
+That's the list. **"I couldn't think of a good test" is not on it** — see the
+next section; it almost always means the decision needs separating from the
+side effect, not that the change is untestable.
+
+Reaching for an exception is worth a sentence in the PR description saying
+which one and why.
+
+## Make the decision testable
+
+Most of this codebase's logic is reachable without touching a filesystem, a
+network, or a prompt — because the decision was deliberately split out into a
+pure function. Keep doing that. It is the difference between a testable change
+and an untestable one:
+
+- `build_command` / `build_login_command` return a configured `Command`, so
+  the env vars can be asserted without ever spawning `claude`
+- `pick_source`, `plan_resume`, `resume_id` decide *what to do*; the caller
+  does the prompting and the I/O
+- `project_slug`, `human_size`, `normalize_version`, `parse_state` are plain
+  value-in, value-out
+
+If a new behaviour is hard to test, that is usually the code telling you the
+decision and the side effect are tangled together. Separate them rather than
+skipping the test.
+
+## Conventions here
+
+- `#[cfg(test)] mod tests` at the bottom of the file being tested
+- No test-only dependencies — plain `cargo test`
+- Filesystem tests build a scratch dir under
+  `std::env::temp_dir().join(format!("cc-<what>-{}", std::process::id()))`
+  and remove it at the end
+- Name tests after the behaviour, as a sentence:
+  `equal_timestamps_are_not_treated_as_newer`, not `test_plan_2`
+- When a test exists because of a specific bug, say so in a comment. Future
+  readers can't otherwise tell a load-bearing assertion from an obvious one:
+  `// Regression: set_default used to rewrite the whole file`
+
+## What is worth a test
+
+Not coverage for its own sake. Test the things that would actually go wrong:
+
+- every branch of a decision function, including the "do nothing" one
+- boundaries — empty input, one item, several, equal values
+- the case the change exists to fix, written so it fails without the fix
+- anything platform-conditional, on both sides (`cfg!(windows)`)
+
+## Before pushing
+
+`cargo test --release` — the release profile, matching CI. See `CLAUDE.md` for
+the full check set.

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+# Personal, per-machine Claude Code settings — .claude/rules/ IS committed
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,4 +17,9 @@ cargo test --release                          # tests, release profile
 To auto-fix formatting before the check: `cargo fmt --all`.
 
 If you touched shell files (`claude-switch.sh`, shell templates), the **Shell**
-workflow also runs `zsh -n` / `bash -n` syntax checks on them.
+workflow also syntax-checks them — `zsh -n` on `claude-switch.sh` and
+`shell/init.zsh`, `bash -n` on `shell/init.bash` and `shell/claude-wrapper.sh`,
+and a PowerShell parse of `shell/init.ps1`.
+
+Project conventions beyond the build live in `.claude/rules/` — they load
+automatically when the files they govern are in play.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,16 +23,7 @@ and a PowerShell parse of `shell/init.ps1`.
 
 ## Everything else lives in `.claude/rules/`
 
-Most of these load on their own when the files they govern come into play. But
-a path-scoped rule can't fire before you've opened the file — when you're
-planning, or creating one — so this index is the backstop. **Read the rule
-before starting work it covers.**
-
-| Rule | Applies when | In one line |
-| --- | --- | --- |
-| `commits-and-prs.md` | always | The PR title becomes the commit and sets the release version. One topic per PR. Never amend or rebase. |
-| `tests.md` | Rust changes | Almost every code change ships a test that fails without it. |
-| `i18n.md` | Rust changes | Every string a person reads is a `Msg` with an arm per language. Never `println!` prose. |
-| `shell-parity.md` | Rust or `claude-switch.sh` | Bug fixes land in the zsh script too, always. Features whenever it can. |
-| `cli-completions.md` | new command/flag/argument | Complete it in all three shells, same commit. |
-| `readme-parity.md` | any `README*.md` | Change one README, change all of them. Translated samples come from a real run. |
+Project conventions beyond the build — commits and PR scope, tests, i18n,
+shell parity, completions, README parity. Most load on their own when the
+files they govern come into play, but a path-scoped rule can't fire before
+you've opened the file. Look there before starting work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,5 +21,18 @@ workflow also syntax-checks them — `zsh -n` on `claude-switch.sh` and
 `shell/init.zsh`, `bash -n` on `shell/init.bash` and `shell/claude-wrapper.sh`,
 and a PowerShell parse of `shell/init.ps1`.
 
-Project conventions beyond the build live in `.claude/rules/` — they load
-automatically when the files they govern are in play.
+## Everything else lives in `.claude/rules/`
+
+Most of these load on their own when the files they govern come into play. But
+a path-scoped rule can't fire before you've opened the file — when you're
+planning, or creating one — so this index is the backstop. **Read the rule
+before starting work it covers.**
+
+| Rule | Applies when | In one line |
+| --- | --- | --- |
+| `commits-and-prs.md` | always | The PR title becomes the commit and sets the release version. One topic per PR. Never amend or rebase. |
+| `tests.md` | Rust changes | Almost every code change ships a test that fails without it. |
+| `i18n.md` | Rust changes | Every string a person reads is a `Msg` with an arm per language. Never `println!` prose. |
+| `shell-parity.md` | Rust or `claude-switch.sh` | Bug fixes land in the zsh script too, always. Features whenever it can. |
+| `cli-completions.md` | new command/flag/argument | Complete it in all three shells, same commit. |
+| `readme-parity.md` | any `README*.md` | Change one README, change all of them. Translated samples come from a real run. |


### PR DESCRIPTION
Six rules under `.claude/rules/`, each encoding something that has already gone wrong in this repo — three of them were caught only by a follow-up catch-up PR.

Most are **path-scoped**, so they load only when the files they govern are in play rather than sitting in every session's context. One is deliberately unscoped.

## `commits-and-prs.md` — unscoped, loads every session

The repo squash-merges, so **the PR title becomes the commit on `master` verbatim**, and `release-please` reads it to build the changelog and pick the version. Nothing in CI validates it, and once merged the tag is already generated.

- `chore:` on a user-facing fix → absent from the changelog, no version bump, ships invisibly
- `feat:` on a fix → a minor promising a feature there isn't one
- a breaking change without `!` → ships as a minor, upgrades break

Carries the prefix table straight from `release-please-config.json`, plus **one topic per PR** and the no-amend / no-rebase history rules. Unscoped because it applies whatever you touch.

## `tests.md` — Rust changes

**Almost every code change ships a test that fails without it**, same PR. Exceptions are a short closed list: comments, renames, formatting. "I couldn't think of a good test" is explicitly *not* on it — here that nearly always means the decision and the side effect are tangled, which is why `build_command`, `pick_source`, `plan_resume` and friends exist as pure functions.

#61, #62, #64 and #65 all merged with no tests; #66 caught up after release.

## `i18n.md` — Rust changes

Every string a person reads is a `Msg` variant with an arm per language. A bare `println!` of prose compiles, looks fine in English, and is untranslated forever with nothing in the build or CI to say so. Names the narrow exceptions — machine-consumed output (`activate`, `completions`, `--json`) and OS error text — because they're real and would otherwise get lawyered.

## `shell-parity.md` — Rust or `claude-switch.sh`

- **Bug fixes: always, no test to apply.** If the script has the code path, it has the bug. A one-sided fix ships a changelog entry claiming it's fixed while half the users still hit it — worse than not fixing it, because now nobody looks again.
- **Features: if the script can support it without trouble, it must.**
- **Skipping is a decision written into the PR description**, never silent. Carries the table of the five Rust-only commands with the reason for each.

## `cli-completions.md` — `src/main.rs`, `completions.rs`, `shell/init.*`

A command isn't done until it completes, in all three shells, same commit. `sessions`, `session` and `resume-hook` all shipped with none; #84 caught up. Dynamic values come from `src/commands/completions.rs`, not a list hardcoded three times. Includes the stub-the-primitives technique for verifying behaviour, since CI only checks that these files parse.

## `readme-parity.md` — `README*.md`

Globbed rather than naming today's two files, so a third language is covered the day it's added, not the day someone remembers this rule exists. Change one README, change all of them, same commit. #76, #77 and #78 each updated only the English one; #80 caught up.

Translated console samples must come from a real run in that language (`CLAUDE_ACC_LANG=ru …`), never a hand translation — those drift from `src/i18n.rs` the moment a string changes.

## `CLAUDE.md`

Two small changes: the Shell workflow line was stale after #84 (it parses `init.ps1` now), and a closing pointer at `.claude/rules/`, since a path-scoped rule can't fire while you're still planning or about to create the file it governs. Deliberately a pointer and not an index — restating the rules would just start drifting from them.

## Note on format

`.claude/rules/*.md` with optional `paths:` frontmatter is the documented mechanism ([memory docs](https://code.claude.com/docs/en/memory.md) § "Organize rules with `.claude/rules/`") — verified against the current docs rather than written from memory.

`.gitignore` gains `.claude/settings.local.json`, so committing `.claude/` never sweeps up personal settings.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)