### PR TITLE
fix: seed accounts that have a symlinked skill, agent or command

### DIFF
--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -885,8 +885,10 @@ _claude_acc_seed_from_default() {
 
     for d in "${dirs[@]}"; do
         if [[ -d "$source/$d" && ! -e "$target/$d" ]]; then
-            # Skip empty source dirs.
-            count=$(find "$source/$d" -type f 2>/dev/null | wc -l | tr -d ' ')
+            # Skip empty source dirs. Symlinks count as entries: a
+            # directory holding only a symlinked skill is not empty, and
+            # `cp -R` carries the link over as a link.
+            count=$(find "$source/$d" \( -type f -o -type l \) 2>/dev/null | wc -l | tr -d ' ')
             (( count == 0 )) && continue
             cp -R "$source/$d" "$target/$d"
             local plural=""

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -83,16 +83,133 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<usize> {
         let entry = entry?;
         let path = entry.path();
         let dst_path = dst.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
+        let file_type = entry.file_type()?;
+
+        if file_type.is_symlink() {
+            // Recreate the link instead of following it. `fs::copy` refuses a
+            // symlink to a *directory* outright, which aborted the whole seed
+            // partway through and left a half-copied account behind — and
+            // someone who symlinked a skill into ~/.claude meant to keep one
+            // copy of it, so duplicating the tree into every account would
+            // fork it silently. Links point outside the config dir in
+            // practice, and stay correct from anywhere.
+            copy_symlink(&path, &dst_path)?;
+            count += 1;
+        } else if file_type.is_dir() {
             count += copy_dir_recursive(&path, &dst_path)?;
-        } else {
+        } else if file_type.is_file() {
             fs::copy(&path, &dst_path)?;
             count += 1;
         }
+        // Anything else — a socket, a fifo — is not configuration. Skipping
+        // it silently beats failing the seed over something nobody meant to
+        // copy.
     }
     Ok(count)
 }
 
+#[cfg(unix)]
+fn copy_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+    let target = fs::read_link(src)?;
+    // A leftover from an earlier partial seed would make the create fail.
+    let _ = fs::remove_file(dst);
+    std::os::unix::fs::symlink(target, dst)
+}
+
+#[cfg(windows)]
+fn copy_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+    // Creating a symlink on Windows needs Developer Mode or elevation, so
+    // follow it instead: a copy of the contents is worse than a link, but it
+    // is far better than failing the seed. `metadata` follows the link.
+    let meta = fs::metadata(src)?;
+    if meta.is_dir() {
+        copy_dir_recursive(src, dst).map(|_| ())
+    } else {
+        fs::copy(src, dst).map(|_| ())
+    }
+}
+
 fn plural(n: usize) -> &'static str {
     if n == 1 { "" } else { "s" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(what: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("cc-seed-{}-{}", what, std::process::id()));
+        let _ = fs::remove_dir_all(&d);
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_symlinked_directory_does_not_abort_the_copy_and_stays_a_link() {
+        // Regression: `fs::copy` refuses a symlink to a directory, so a single
+        // symlinked skill — `~/.claude/skills/foo -> ~/elsewhere/foo` is an
+        // ordinary setup — failed the whole seed partway through, leaving a
+        // half-populated account and exit 1.
+        let dir = scratch("symlink");
+        let src = dir.join("src");
+        let dst = dir.join("dst");
+        let outside = dir.join("outside");
+
+        fs::create_dir_all(outside.join("nested")).unwrap();
+        fs::write(outside.join("nested/file.md"), "linked").unwrap();
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("plain.md"), "plain").unwrap();
+        std::os::unix::fs::symlink(&outside, src.join("linked-dir")).unwrap();
+        std::os::unix::fs::symlink(outside.join("nested/file.md"), src.join("linked-file"))
+            .unwrap();
+
+        let count = copy_dir_recursive(&src, &dst).unwrap();
+        assert_eq!(count, 3, "every entry should be accounted for");
+
+        // The plain file is copied; both links are recreated as links, not
+        // followed into duplicated trees.
+        assert_eq!(fs::read_to_string(dst.join("plain.md")).unwrap(), "plain");
+        assert!(
+            fs::symlink_metadata(dst.join("linked-dir"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(
+            fs::symlink_metadata(dst.join("linked-file"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(fs::read_link(dst.join("linked-dir")).unwrap(), outside);
+        // And they still resolve from the new location.
+        assert_eq!(
+            fs::read_to_string(dst.join("linked-dir/nested/file.md")).unwrap(),
+            "linked"
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_dangling_symlink_is_carried_over_rather_than_failing_the_seed() {
+        let dir = scratch("dangling");
+        let src = dir.join("src");
+        let dst = dir.join("dst");
+        fs::create_dir_all(&src).unwrap();
+        std::os::unix::fs::symlink(dir.join("gone"), src.join("broken")).unwrap();
+
+        let count = copy_dir_recursive(&src, &dst).unwrap();
+        assert_eq!(count, 1);
+        assert!(
+            fs::symlink_metadata(dst.join("broken"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
 }


### PR DESCRIPTION
Found while implementing plugin seeding — the feature could not be demonstrated on my own machine because seeding aborted before it got that far. Filed separately per `.claude/rules/commits-and-prs.md`: this is a bug in existing behaviour with its own changelog line, and the feature stacks on top of it.

## The bug

`copy_dir_recursive` sent every non-directory entry to `fs::copy`, which refuses a symlink to a *directory*. A single symlinked skill is enough:

```
$ ls -l ~/.claude/skills/orchestration
lrwxr-xr-x  ~/.claude/skills/orchestration -> ~/.agents/skills/orchestration

$ claude-acc clone-settings work
  copied: settings.json
  copied: CLAUDE.md
  copied: agents/ (33 files)
  copied: skills/ (93 files)
clone-settings: the source path is neither a regular file nor a symlink to a regular file
$ echo $?
1
```

Reproduced on `master` (`9264a2a`). `add --seed` takes the same path, so a new account gets created, half-seeded, and then reports failure.

Symlinking a skill or agent directory into `~/.claude` is how people share one copy between tools, so this is not an exotic setup — it is the one on this machine.

## The fix

Links are recreated as links instead of being followed. That is the right behaviour independently of the crash: whoever made the symlink wanted one copy, and following it would fork the tree into every account silently. In practice these links point outside the config dir, so they resolve correctly from the new account too.

Also: a dangling link is carried over rather than failing the seed, and anything that is neither a file, a directory nor a link — a socket, a fifo — is skipped rather than aborting, since none of that is configuration.

Windows creates symlinks only with Developer Mode or elevation, so there the link is followed and its contents copied. A duplicated tree is worse than a link; it is much better than a seed that fails.

## Shell parity

`claude-switch.sh` uses `cp -R`, which preserves links, so it never had this bug — checked rather than assumed, per `.claude/rules/shell-parity.md`.

It did have a smaller divergence in the same function: the "skip empty source dirs" guard counted with `find -type f`, which does not see symlinks, so a directory holding only a symlinked skill counted as empty and was skipped while the Rust copied it. Now `\( -type f -o -type l \)`, matching.

## Tests

Two, both `#[cfg(unix)]` since they create symlinks:

- a directory containing a plain file, a symlinked directory and a symlinked file copies all three, and both links arrive as links pointing where they did — plus the linked content still resolves through the copy;
- a dangling link is carried over instead of failing.

Verified against the real case as well: `clone-settings` now completes with exit 0 on this machine, and `skills/orchestration` arrives as a link to `~/.agents/skills/orchestration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)