### PR TITLE
ci: make every check report on a pull request, so it can be required

### DIFF
--- a/.claude/rules/platform-gating.md
+++ b/.claude/rules/platform-gating.md
@@ -1,0 +1,60 @@
+---
+paths:
+  - "src/*.rs"
+  - "src/commands/*.rs"
+---
+
+# `cfg`-gate the module, not each item inside it
+
+CI builds on Linux, macOS and Windows with `-D warnings`, so on every
+platform *unused* is an error. That makes platform gating asymmetric in a way
+that is easy to get wrong: gating what obviously needs gating, and leaving
+behind something that only that code used.
+
+The shape that bit us (#103, fixed in #104): two tests that create symlinks,
+correctly marked `#[cfg(unix)]` — and a `scratch()` helper and a
+`use super::*` left outside the gate. On Windows the module compiled to
+nothing but an unused import and an unused function. Every other job passed;
+Windows failed on dead code.
+
+## The rule
+
+**If every test in a module is gated, gate the module:**
+
+```rust
+// Every test here creates symlinks, so the whole module is unix-only.
+#[cfg(all(test, unix))]
+mod tests {
+```
+
+Not `#[cfg(test)] mod tests` with a `#[cfg(unix)]` on each `#[test]` — that
+leaves helpers and imports stranded.
+
+**If only some tests are gated**, then the helpers they use must be gated the
+same way, and so must any import only they need. Gating a whole module is
+simpler and states the reason once, so prefer restructuring until that is
+possible.
+
+The same applies outside tests: a `#[cfg(not(windows))]` function whose only
+caller is also `#[cfg(not(windows))]` is fine, but a constant, an import, or
+a helper used *only* from gated code needs the same gate.
+
+## Before pushing
+
+Type-check the platform you are not on. It is about a second, and it is the
+only local check that sees this class at all:
+
+```sh
+RUSTFLAGS="-D warnings" cargo clippy --all-targets --target x86_64-pc-windows-msvc
+```
+
+`rustup target add x86_64-pc-windows-msvc` once, first. On a Windows machine,
+cross-check `x86_64-unknown-linux-gnu` instead — the direction that matters
+is "the platform whose `cfg` branches your local build never compiled".
+
+## Merging
+
+Green CI is a precondition for merge, not a formality. Where the ruleset lets
+an admin override it, the override exists to get past the *review*
+requirement on a solo repo — never past a red build. Read the check results
+before merging; do not chain a merge onto the command that watches them.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,13 +1,11 @@
 name: Rust
 
 on:
+  # No `paths` filter here on purpose. A required status check that never
+  # runs never reports, and the pull request waits on it forever — so every
+  # PR runs this, including one that only touches docs. The `push` filter
+  # below keeps that from costing anything on master.
   pull_request:
-    paths:
-      - 'src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'shell/**'
-      - '.github/workflows/rust.yml'
   push:
     branches: [master]
     paths:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,11 +1,11 @@
 name: Shell
 
 on:
+  # No `paths` filter here on purpose. A required status check that never
+  # runs never reports, and the pull request waits on it forever — so every
+  # PR runs this, including one that only touches docs. The `push` filter
+  # below keeps that from costing anything on master.
   pull_request:
-    paths:
-      - 'claude-switch.sh'
-      - 'shell/**'
-      - '.github/workflows/shell.yml'
   push:
     branches: [master]
     paths:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,27 @@ cargo test --release                          # tests, release profile
 
 To auto-fix formatting before the check: `cargo fmt --all`.
 
+### If you touched anything `cfg`-gated, add the Windows cross-check
+
+CI runs the four commands above on Linux, macOS **and Windows**. The four
+above only cover the platform you are sitting on, so a `#[cfg(unix)]` test —
+or the helper it leaves behind — can be clean locally and dead code there,
+which `-D warnings` turns into a failed build:
+
+```sh
+rustup target add x86_64-pc-windows-msvc      # once
+RUSTFLAGS="-D warnings" cargo clippy --all-targets --target x86_64-pc-windows-msvc
+```
+
+It is a type-check, not a run, so it takes about a second. Worth it any time
+a `cfg` appears in the diff — see `.claude/rules/platform-gating.md`.
+
 If you touched shell files (`claude-switch.sh`, shell templates), the **Shell**
 workflow also syntax-checks them — `zsh -n` on `claude-switch.sh` and
-`shell/init.zsh`, `bash -n` on `shell/init.bash` and `shell/claude-wrapper.sh`,
-and a PowerShell parse of `shell/init.ps1`.
+`shell/init.zsh`, `bash -n` on `shell/init.bash` and both wrappers
+(`shell/claude-wrapper.sh`, `shell/claude-vscode-wrapper.sh`), a `sh -n` pass
+over the two wrappers since they declare `#!/bin/sh`, and a PowerShell parse
+of `shell/init.ps1`. A new shell file is not covered until it is added there.
 
 ## Everything else lives in `.claude/rules/`
 


### PR DESCRIPTION
Follow-up to #103/#104. Ordered first because the ruleset change it enables can only be made once the checks always report.

## What went wrong

The `Master` ruleset requires one approving review and says nothing about the build. So CI was advisory: #103 was merged while the Windows job was already failing, and master went red. #104 fixed the code; this fixes the reason it could land.

## Why the workflows change first

Making the four jobs required status checks needs them to always report. Both workflows filtered the `pull_request` trigger by `paths`, and **a required check that never runs never reports** — the PR then sits waiting on it forever. A README-only PR would have been unmergeable.

The filter is dropped on `pull_request` only. `push` keeps it, so a docs-only commit on master still triggers nothing. The cost is that a docs-only PR now runs the full matrix — about a minute — which is the price of having checks that can gate a merge at all.

## The ruleset change this unblocks

Once merged, `ubuntu-latest`, `macos-latest`, `windows-latest` and `zsh -n / bash -n` become required status checks. The review requirement stays as it is.

Stated plainly, since it is the honest limit of this: with a review still required and no second reviewer, merging a PR here still needs `--admin`, and `--admin` bypasses required checks too. So this does not make a red merge *impossible* — it makes it impossible by accident. `gh pr merge` without the override now refuses on a red build, the PR page shows the block, and the override becomes a deliberate act rather than the only way through.

## The local check that would have caught it

The four commands in CLAUDE.md compile only the platform you are on, so they structurally cannot see this class. #103's failure was a `#[cfg(unix)]` test whose helper and `use` were left outside the gate — dead code under Windows's `-D warnings`.

```sh
rustup target add x86_64-pc-windows-msvc      # once
RUSTFLAGS="-D warnings" cargo clippy --all-targets --target x86_64-pc-windows-msvc
```

A type-check, about a second. Now in CLAUDE.md next to the other four.

`.claude/rules/platform-gating.md` states the rule that avoids the class rather than catching it: gate the module, not each item inside it, so helpers and imports cannot be stranded on the platform where nothing uses them. It also records that an admin override is for getting past the review requirement on a solo repo, never past a red build — the mistake that produced this PR.

## Also

CLAUDE.md's shell section was a release behind — no mention of `claude-vscode-wrapper.sh` or the `sh -n` pass added alongside it in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)