### PR TITLE
ci: pin actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+
+# Two ecosystems, both grouped, both weekly. Grouping matters more than the
+# schedule here: every PR in this repo needs a merge that overrides the review
+# requirement, so ten separate patch bumps cost ten of those. One PR a week
+# costs one.
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      # release-please reads this prefix to build the changelog and pick the
+      # next version. `chore:` keeps dependency bumps out of the release notes
+      # and still gets them a patch bump — see .claude/rules/commits-and-prs.md.
+      prefix: chore
+    groups:
+      # The RustCrypto stack decrypts desktop profile tokens; they move
+      # together and are reviewed together.
+      crypto:
+        patterns:
+          - aes
+          - cbc
+          - hmac
+          - pbkdf2
+          - sha1
+          - sha2
+      # Everything else, minor and patch in one PR. A major bump comes on its
+      # own, because it is a decision rather than a bump.
+      rust-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name:        ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           config-file: release-please-config.json
@@ -47,13 +47,16 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
         with:
+          # Spelled out because the pin replaced the `@stable` ref that used
+          # to carry this.
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Install cross-compilation tools (Linux aarch64)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,14 +35,17 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install Rust (stable, with rustfmt + clippy)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
         with:
+          # Spelled out because the pin replaced the `@stable` ref that used
+          # to carry this.
+          toolchain: stable
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: cargo fmt --check
         run: cargo fmt --all --check

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -25,7 +25,7 @@ jobs:
     name: zsh -n / bash -n
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install zsh
         run: sudo apt-get update && sudo apt-get install -y zsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,30 @@ workflow also syntax-checks them — `zsh -n` on `claude-switch.sh` and
 over the two wrappers since they declare `#!/bin/sh`, and a PowerShell parse
 of `shell/init.ps1`. A new shell file is not covered until it is added there.
 
+## Actions are pinned to a commit SHA
+
+Every `uses:` in `.github/workflows/` names a commit, with the tag it came
+from in a trailing comment:
+
+```yaml
+- uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+```
+
+A tag is mutable — whoever owns the action can move `v4` to a different
+commit, and CI would run that code with the workflow's token. This repo
+handles other people's credentials, so that is not a theoretical worry.
+Dependabot bumps these weekly, SHA and comment together.
+
+**Adding a new action means pinning it too.** Resolve the tag first:
+
+```sh
+gh api repos/<owner>/<repo>/git/ref/tags/<tag> --jq '.object.sha'
+```
+
+If the action selects its behaviour from the ref it is used at — as
+`dtolnay/rust-toolchain@stable` did — say that explicitly in `with:`, because
+the pin takes the ref away.
+
 ## Everything else lives in `.claude/rules/`
 
 Project conventions beyond the build — commits and PR scope, tests, i18n,


### PR DESCRIPTION
## Pinning

All four actions were used at a mutable tag:

```
actions/checkout@v4
dtolnay/rust-toolchain@stable
Swatinem/rust-cache@v2
googleapis/release-please-action@v4
```

A tag is a pointer its owner can move. If any of those four repositories is compromised, or an owner simply retags, CI runs the new code with the workflow's `GITHUB_TOKEN` — and on this repository, whose subject is handling other people's credentials, that is not an abstract concern.

Each is pinned to the commit its tag pointed at when this was written, with the tag in a trailing comment so the pin stays readable:

```yaml
- uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
- uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
- uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
- uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
```

Every SHA was checked back against the tag it claims (`repos/<owner>/<repo>/tags`), not assumed — my first pass had `checkout` commented as v4.3.0 when the commit is v4.4.0.

No version is changed here. `checkout` is on v4 while v7 exists, and `release-please-action` on v4 while v5 does; those are upgrades to decide separately, and Dependabot will now raise them.

### One behavioural subtlety

`dtolnay/rust-toolchain` reads which toolchain to install from **the branch it is used from** — `@stable`, `@nightly`, `@1.75.0`. Pinning a SHA removes that signal. Both call sites now pass `toolchain: stable` explicitly, so the behaviour no longer depends on which branch the pinned commit happens to sit on.

## Dependabot

Cargo (9 direct crates, 57 in the lockfile) and github-actions, weekly, grouped.

Grouping matters more than the schedule. Every PR in this repo is merged with an override of the review requirement, so ten separate patch bumps cost ten of those; one grouped PR costs one.

- **`crypto`** — `aes`, `cbc`, `hmac`, `pbkdf2`, `sha1`, `sha2` in their own group. They decrypt desktop profile tokens, they move together, and they deserve to be read together rather than buried among unrelated bumps.
- **`rust-minor-and-patch`** — everything else, minor and patch, one PR.
- Majors arrive alone, because a major is a decision, not a bump.
- Commit prefixes: `chore` for cargo, `ci` for actions, so release-please keeps them out of the release notes while still cutting a patch — per `.claude/rules/commits-and-prs.md`.

## Alerts were off

Checked rather than assumed:

```
GET /repos/.../vulnerability-alerts        → 404   (alerts disabled)
GET /repos/.../automated-security-fixes    → 200   (auto-fixes enabled)
```

Auto-fixes with alerts off is an inert setting — nothing to fix when nothing is reported. Alerts are now enabled (`PUT` → 204, `GET` → 204).

## Also

`CLAUDE.md` gains a short section so a new action does not arrive on a floating tag, including how to resolve a tag to its SHA and the note about actions that take meaning from their ref.

## Verification

The workflows in this PR run themselves, so a bad pin fails here rather than later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)