### PR TITLE
ci: keep major bumps out of the Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,11 @@ updates:
     groups:
       # The RustCrypto stack decrypts desktop profile tokens; they move
       # together and are reviewed together.
+      #
+      # `update-types` on every group, not just the last: a group without it
+      # takes majors too. The first run proved it — six RustCrypto majors
+      # arrived here as one PR that did not compile, because `cipher` 0.5
+      # renamed the block-mode traits (#111).
       crypto:
         patterns:
           - aes
@@ -28,8 +33,13 @@ updates:
           - pbkdf2
           - sha1
           - sha2
-      # Everything else, minor and patch in one PR. A major bump comes on its
-      # own, because it is a decision rather than a bump.
+        update-types:
+          - minor
+          - patch
+      # Everything else, minor and patch in one PR. A major arrives on its
+      # own — ungrouped, because it is a decision rather than a bump, and
+      # because bundling one with routine updates means a failing PR nobody
+      # can split.
       rust-minor-and-patch:
         patterns:
           - "*"
@@ -49,3 +59,6 @@ updates:
       actions:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Follow-up to #107, which introduced the gap, and to #108/#111 which showed what it costs.

The config I wrote in #107 says in its own comment that *"a major bump comes on its own, because it is a decision rather than a bump"* — and then puts `update-types` on only one of the three groups. A group without it takes everything, majors included.

The very first Dependabot run demonstrated both failure modes:

- **#109** — six RustCrypto majors grouped into one PR that failed on all three platforms, because `cipher` 0.5 renames the block-mode traits. A grouped PR that fails cannot be split: you either fix every crate in it or drop the lot. It ended up superseded by #111 with the migration attached.
- **#108** — `actions/checkout` v4 → **v7** and `release-please-action` v4 → **v5**, arriving as a "routine" actions bump. Both turned out fine (node24 runtimes, plus a fork-PR restriction on triggers this repo does not use), but that is something you find out by reading three sets of release notes, not something you merge because the group is green.

`update-types: [minor, patch]` is now on every group, so a major comes through on its own and gets read on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)