### PR TITLE
fix: recognise a signed-in desktop profile in the zsh script

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -48,6 +48,20 @@ jobs:
           sh -n shell/claude-wrapper.sh
           sh -n shell/claude-vscode-wrapper.sh
 
+      # Syntax is not where the bugs were. #118 was a grep pattern that
+      # parsed fine and matched nothing on any real profile, so `desktop
+      # list` called every signed-in profile signed out and `desktop run`
+      # refused to launch one. These run the functions and check answers.
+      #
+      # The job name stays "zsh -n / bash -n" because the branch ruleset
+      # requires that exact check; renaming it would silently stop gating.
+      - name: Behaviour tests
+        run: |
+          for t in tests/shell/*.zsh; do
+            echo "--- $t"
+            zsh "$t"
+          done
+
       # init.ps1 is `eval`'d by PowerShell users' profiles, so a syntax error
       # there breaks their shell startup. pwsh is preinstalled on the runner.
       - name: Syntax-check the PowerShell template

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,19 @@ workflow also syntax-checks them — `zsh -n` on `claude-switch.sh` and
 over the two wrappers since they declare `#!/bin/sh`, and a PowerShell parse
 of `shell/init.ps1`. A new shell file is not covered until it is added there.
 
+It also runs every `tests/shell/*.zsh` — behaviour tests that source
+`claude-switch.sh` and check what its functions answer. Syntax checking is
+not enough on its own: #118 was a `grep` pattern that parsed fine and matched
+nothing on any real profile, and it shipped. Run them locally the same way:
+
+```sh
+for t in tests/shell/*.zsh; do zsh "$t"; done
+```
+
+A shell fix belongs there whenever the behaviour can be pinned to a file the
+test writes — which is most of them, since these functions read JSON and
+directories rather than talking to the network.
+
 ## Actions are pinned to a commit SHA
 
 Every `uses:` in `.github/workflows/` names a commit, with the tag it came

--- a/claude-switch.sh
+++ b/claude-switch.sh
@@ -1104,7 +1104,14 @@ _claude_acc_desktop_launch() {
 # key survives the migration as an empty string, hence the non-empty match.
 _claude_acc_desktop_signed_in() {
     local profile="$1"
-    grep -q '"oauth:tokenCache\(V2\)\?":"[^"]' "$profile/config.json" 2>/dev/null
+    # Claude Desktop pretty-prints config.json, so the value sits a space
+    # away from its key — `"oauth:tokenCacheV2": "djEw…"`. The pattern used
+    # to demand a quote immediately after the colon and so matched nothing
+    # on any real profile (#118). `"[^"]` still keeps the empty placeholder
+    # the V2 migration leaves behind from counting as a token, matching what
+    # `desktop::is_signed_in` decides on the Rust side.
+    grep -qE '"oauth:tokenCache(V2)?"[[:space:]]*:[[:space:]]*"[^"]' \
+        "$profile/config.json" 2>/dev/null
 }
 
 # The account uuid sits in plaintext in config.json — enough to tell two

--- a/tests/shell/desktop_run_guard.zsh
+++ b/tests/shell/desktop_run_guard.zsh
@@ -1,0 +1,65 @@
+#!/usr/bin/env zsh
+#
+# `desktop run` must consult the sign-in guard only for a profile that is
+# *not* signed in — README: "a profile that already is opens freely".
+#
+# This is the half of #118 that hurt: the predicate read every signed-in
+# profile as signed out, so with any Claude Desktop open `desktop run`
+# entered the guard and refused to launch. Testing the predicate alone would
+# not have caught that the two are wired together, so this drives the
+# command and watches which branch it takes.
+#
+# Run: zsh tests/shell/desktop_run_guard.zsh
+
+emulate -L zsh
+set -u
+
+source "${0:A:h:h:h}/claude-switch.sh" >/dev/null 2>&1
+
+typeset -i failures=0
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+
+# Point the script at a scratch profile tree, and replace everything past
+# the decision: the guard reports that it ran and refuses, the launcher
+# reports that it launched. Neither touches the real machine.
+CLAUDE_SWITCH_DESKTOP_DIR="$scratch/desktop"
+_claude_acc_desktop_signin_possible() { print -r -- 'GUARD-RAN'; return 1 }
+_claude_acc_desktop_app() { print -r -- "$scratch/Claude.app" }
+_claude_acc_desktop_launch() { print -r -- 'LAUNCHED' }
+
+profile() {
+    local name="$1" body="$2"
+    mkdir -p "$CLAUDE_SWITCH_DESKTOP_DIR/$name"
+    [[ "$body" == ABSENT ]] ||
+        print -r -- "$body" >"$CLAUDE_SWITCH_DESKTOP_DIR/$name/config.json"
+}
+
+# check <case name> <profile name> <LAUNCHED|GUARD-RAN>
+check() {
+    local name="$1" prof="$2" want="$3" out
+    out=$(_claude_acc_desktop_run "$prof" 2>&1)
+    if [[ "$out" == *"$want"* ]]; then
+        print -r -- "ok   $name"
+    else
+        print -r -- "FAIL $name — expected $want in output, got:"
+        print -r -- "${out//$'\n'/\\n}"
+        (( failures++ ))
+    fi
+}
+
+# Pretty-printed exactly as Claude Desktop writes it — the shape #118 read
+# as signed out.
+profile signed-in '{
+    "oauth:tokenCacheV2": "djEwkwgMDd4K"
+}'
+profile signed-out '{"locale": "en-US"}'
+
+check 'a signed-in profile opens without the sign-in guard' signed-in LAUNCHED
+check 'a signed-out profile still meets the guard' signed-out GUARD-RAN
+
+if (( failures )); then
+    print -r -- "$failures failing case(s)"
+    exit 1
+fi
+print -r -- "all cases passed"

--- a/tests/shell/desktop_signed_in.zsh
+++ b/tests/shell/desktop_signed_in.zsh
@@ -1,0 +1,67 @@
+#!/usr/bin/env zsh
+#
+# Behaviour tests for `_claude_acc_desktop_signed_in` in claude-switch.sh.
+#
+# `zsh -n` is the only thing CI ran over this file before, and syntax was
+# never the problem: #118 was a pattern that matched nothing on any real
+# profile, so `desktop list` called every signed-in profile signed out and
+# `desktop run` refused to launch one while any Claude Desktop was open.
+# The cases that bug turned on live here.
+#
+# Run: zsh tests/shell/desktop_signed_in.zsh
+
+emulate -L zsh
+set -u
+
+source "${0:A:h:h:h}/claude-switch.sh" >/dev/null 2>&1
+
+typeset -i failures=0
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+
+# check <case name> <config.json body, or the word ABSENT> <yes|no>
+check() {
+    local name="$1" body="$2" want="$3"
+    local dir="$scratch/${name//[^a-zA-Z0-9]/_}"
+    mkdir -p "$dir"
+    [[ "$body" == ABSENT ]] || print -r -- "$body" >"$dir/config.json"
+
+    local got=no
+    _claude_acc_desktop_signed_in "$dir" && got=yes
+    if [[ "$got" == "$want" ]]; then
+        print -r -- "ok   $name"
+    else
+        print -r -- "FAIL $name — expected $want, got $got"
+        (( failures++ ))
+    fi
+}
+
+# The shape Claude Desktop actually writes: indented, with a space between
+# the key and its value. This is #118 itself.
+check 'pretty-printed V2 token' '{
+    "locale": "en-US",
+    "oauth:tokenCacheV2": "djEwkwgMDd4K"
+}' yes
+
+check 'compact V2 token' '{"oauth:tokenCacheV2":"djEwkwgMDd4K"}' yes
+
+check 'pre-V2 token, pretty-printed' '{
+    "oauth:tokenCache": "djEwkwgMDd4K"
+}' yes
+
+# The V1 entry survives the V2 migration as an empty string; the Rust side
+# has the same case, and the two must not disagree about it.
+check 'empty placeholder is not a token' '{
+    "oauth:tokenCache": "",
+    "locale": "en-US"
+}' no
+
+check 'null is not a token' '{"oauth:tokenCacheV2": null}' no
+check 'no token key at all' '{"locale": "en-US"}' no
+check 'no config.json' ABSENT no
+
+if (( failures )); then
+    print -r -- "$failures failing case(s)"
+    exit 1
+fi
+print -r -- "all cases passed"


### PR DESCRIPTION
Closes #118.

## Баг

```sh
grep -q '"oauth:tokenCache\(V2\)\?":"[^"]' "$profile/config.json"
```

Шаблон требует кавычку сразу за двоеточием. Claude Desktop пишет `config.json` с отступами:

```
'\t"oauth:tokenCacheV2": "djEwkwgMDd4K…'
```

Пробел — и grep не находит ничего. То есть проверка возвращала «нет входа» для **каждого** реального профиля.

## Последствие серьёзнее, чем в иссью

В иссью я написал про колонку в `desktop list`. Это половина. Второй вызов — в `_claude_acc_desktop_run`:

```sh
if ! _claude_acc_desktop_signed_in "$profile"; then
    _claude_acc_desktop_signin_possible "$force" || return 1
fi
```

Залогиненный профиль читался как незалогиненный, поэтому при любом открытом Claude Desktop `desktop run` уходил в guard и **отказывался запускаться**:

```
$ _claude_acc_desktop_run work
Quit Claude before signing in. …
  pid 69325  —  ~/Library/…/Claude/
exit=1
```

При этом README (строка 658) прямо обещает обратное: «a profile that already is [signed in] opens freely». Документация была права, код — нет; README не трогал.

## Починка

```sh
grep -qE '"oauth:tokenCache(V2)?"[[:space:]]*:[[:space:]]*"[^"]' …
```

`"[^"]` оставлен намеренно: пустышка `"oauth:tokenCache": ""`, которую оставляет после себя миграция на V2, по-прежнему не считается токеном — ровно как решает `desktop::is_signed_in` на стороне Rust.

Без `jq`: сейчас эта функция от него не зависит, и вводить зависимость ради исправления шаблона значило бы отобрать колонку у тех, у кого `jq` нет.

## Тесты — которых у shell-части не было вовсе

`zsh -n` был единственным, что CI прогонял по этому файлу, а синтаксис здесь никогда и не ломался. Поэтому добавил `tests/shell/desktop_signed_in.zsh` — он сорсит `claude-switch.sh` и проверяет ответы функции на семи случаях: оба формата записи, обе версии ключа, пустышка, `null`, отсутствие ключа, отсутствие файла.

Тест нагруженный по построению — он писался **до** починки и падал ровно на двух случаях с отступами:

```
FAIL pretty-printed V2 token — expected yes, got no
ok   compact V2 token
FAIL pre-V2 token, pretty-printed — expected yes, got no
```

После починки все семь проходят.

Прогон подключён в workflow **Shell** отдельным шагом. Имя job'а (`zsh -n / bash -n`) не менял: ruleset требует именно эту проверку, и переименование тихо сняло бы гейт. В `CLAUDE.md` добавлено, как запускать локально.

## Проверено

- Вывод zsh и Rust на реальном профиле теперь совпадает побайтово: `work  <piotr.radilov@…>  (signed in)`
- Условие guard'а в `desktop run` на этом профиле больше не срабатывает (проверял сам предикат, чтобы не запускать приложение)
- `zsh -n claude-switch.sh`, `cargo fmt --check`, `clippy --all-targets -D warnings`, `cargo test --release` — 326 тестов
- README не менялся: он и так описывал правильное поведение