### PR TITLE
test: run the shell tests against a scratch home

### DIFF
--- a/tests/shell/desktop_run_guard.zsh
+++ b/tests/shell/desktop_run_guard.zsh
@@ -14,11 +14,18 @@
 emulate -L zsh
 set -u
 
-source "${0:A:h:h:h}/claude-switch.sh" >/dev/null 2>&1
-
 typeset -i failures=0
 scratch=$(mktemp -d)
 trap 'rm -rf "$scratch"' EXIT
+
+# Sourcing the script runs its init, which creates ~/.claude-switch/ and
+# regenerates the `claude` wrapper inside it. On a machine running the Rust
+# CLI that silently replaces its wrapper with the zsh one, so running the
+# tests breaks the installation. A scratch HOME keeps the real one out of it.
+export HOME="$scratch/home"
+mkdir -p "$HOME"
+
+source "${0:A:h:h:h}/claude-switch.sh" >/dev/null 2>&1
 
 # Point the script at a scratch profile tree, and replace everything past
 # the decision: the guard reports that it ran and refuses, the launcher

--- a/tests/shell/desktop_signed_in.zsh
+++ b/tests/shell/desktop_signed_in.zsh
@@ -13,11 +13,18 @@
 emulate -L zsh
 set -u
 
-source "${0:A:h:h:h}/claude-switch.sh" >/dev/null 2>&1
-
 typeset -i failures=0
 scratch=$(mktemp -d)
 trap 'rm -rf "$scratch"' EXIT
+
+# Sourcing the script runs its init, which creates ~/.claude-switch/ and
+# regenerates the `claude` wrapper inside it. On a machine running the Rust
+# CLI that silently replaces its wrapper with the zsh one, so running the
+# tests breaks the installation. A scratch HOME keeps the real one out of it.
+export HOME="$scratch/home"
+mkdir -p "$HOME"
+
+source "${0:A:h:h:h}/claude-switch.sh" >/dev/null 2>&1
 
 # check <case name> <config.json body, or the word ABSENT> <yes|no>
 check() {


### PR DESCRIPTION
## Problem

`tests/shell/*.zsh` source `claude-switch.sh`, and sourcing it runs
`_claude_switch_init` — which creates `~/.claude-switch/` and regenerates
`~/.claude-switch/bin/claude`.

On a machine running the Rust CLI that overwrites the Rust wrapper with the
zsh one. So the very command CLAUDE.md prescribes before pushing —

```sh
for t in tests/shell/*.zsh; do zsh "$t"; done
```

— silently downgraded the installation it was run on: the zsh wrapper knows
nothing about `claude-acc session preflight`, and (before the fix in the
companion PR) it also re-derived `CLAUDE_CONFIG_DIR` from `$PWD`, overruling
the account `claude-acc run` had just chosen.

Reproduced here: after a test run, `claude-acc run default` inside a linked
directory started `claude` on that directory's account instead of the
standard `~/.claude/` one.

## Fix

Export `HOME` into the scratch directory before the source, so the init
builds its tree there and the real `~/.claude-switch/` is untouched.

## Testing

- `for t in tests/shell/*.zsh; do zsh "$t"; done` — all pass
- `~/.claude-switch/bin/claude` still carries the `Auto-generated by
  claude-acc` header after the run (it did not before)

Tests only; no behaviour change to the shipped script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)